### PR TITLE
Fix for MSVC warning C4702: unreachable code.

### DIFF
--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -1506,9 +1506,11 @@ static enum rmtError InitialiseNetwork()
 
         return RMT_ERROR_NONE;
 
-    #endif
+    #else
 
-    return RMT_ERROR_NONE;
+        return RMT_ERROR_NONE;
+
+    #endif
 }
 
 


### PR DESCRIPTION
There are other warnings but for some reason this warning wouldn't suppress with the build setup I was trying it with.
