### PR TITLE
Custom port configuration

### DIFF
--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -3898,7 +3898,7 @@ static rmtError Remotery_ThreadMain(Thread* thread)
 }
 
 
-static rmtError Remotery_Constructor(Remotery* rmt)
+static rmtError Remotery_Constructor(Remotery* rmt, int port)
 {
     rmtError error;
 
@@ -3918,7 +3918,7 @@ static rmtError Remotery_Constructor(Remotery* rmt)
         return error;
 
     // Create the server
-    New_1(Server, rmt->server, 0x4597);
+    New_1(Server, rmt->server, port);
     if (error != RMT_ERROR_NONE)
         return error;
 
@@ -4078,14 +4078,14 @@ static void Remotery_DestroyThreadSamplers(Remotery* rmt)
 }
 
 
-rmtError _rmt_CreateGlobalInstance(Remotery** remotery)
+rmtError _rmt_CreateGlobalInstance( Remotery** remotery, int port )
 {
-    rmtError error;
+	rmtError error;
 
-    // Creating the Remotery instance also records it as the global instance
-    assert(remotery != NULL);
-    New_0(Remotery, *remotery);
-    return error;
+	// Creating the Remotery instance also records it as the global instance
+	assert( remotery != NULL );
+	New_1( Remotery, *remotery, port );
+	return error;
 }
 
 

--- a/lib/Remotery.h
+++ b/lib/Remotery.h
@@ -237,7 +237,10 @@ typedef enum rmtError
 // TODO: Can embed extern "C" in these macros?
 
 #define rmt_CreateGlobalInstance(rmt)                                               \
-    RMT_OPTIONAL_RET(RMT_ENABLED, _rmt_CreateGlobalInstance(rmt), RMT_ERROR_NONE)
+    RMT_OPTIONAL_RET(RMT_ENABLED, _rmt_CreateGlobalInstance(rmt, 0x4597), RMT_ERROR_NONE)
+
+#define rmt_CreateGlobalInstanceWithPort(rmt, port)									\
+	RMT_OPTIONAL_RET(RMT_ENABLED, _rmt_CreateGlobalInstance(rmt, port), RMT_ERROR_NONE)
 
 #define rmt_DestroyGlobalInstance(rmt)                                              \
     RMT_OPTIONAL(RMT_ENABLED, _rmt_DestroyGlobalInstance(rmt))
@@ -433,7 +436,7 @@ struct rmt_EndOpenGLSampleOnScopeExit
 extern "C" {
 #endif
 
-enum rmtError _rmt_CreateGlobalInstance(Remotery** remotery);
+enum rmtError _rmt_CreateGlobalInstance(Remotery** remotery, int port);
 void _rmt_DestroyGlobalInstance(Remotery* remotery);
 void _rmt_SetGlobalInstance(Remotery* remotery);
 Remotery* _rmt_GetGlobalInstance(void);

--- a/lib/Remotery.h
+++ b/lib/Remotery.h
@@ -236,11 +236,11 @@ typedef enum rmtError
 // Can call remotery functions on a null pointer
 // TODO: Can embed extern "C" in these macros?
 
-#define rmt_CreateGlobalInstance(rmt)                                               \
-    RMT_OPTIONAL_RET(RMT_ENABLED, _rmt_CreateGlobalInstance(rmt, 0x4597), RMT_ERROR_NONE)
+#define rmt_Settings()																\
+	RMT_OPTIONAL_RET(RMT_ENABLED, _rmt_Settings(), NULL )
 
-#define rmt_CreateGlobalInstanceWithPort(rmt, port)									\
-	RMT_OPTIONAL_RET(RMT_ENABLED, _rmt_CreateGlobalInstance(rmt, port), RMT_ERROR_NONE)
+#define rmt_CreateGlobalInstance(rmt)                                               \
+    RMT_OPTIONAL_RET(RMT_ENABLED, _rmt_CreateGlobalInstance(rmt), RMT_ERROR_NONE)
 
 #define rmt_DestroyGlobalInstance(rmt)                                              \
     RMT_OPTIONAL(RMT_ENABLED, _rmt_DestroyGlobalInstance(rmt))
@@ -266,6 +266,15 @@ typedef enum rmtError
 #define rmt_EndCPUSample()                                                          \
     RMT_OPTIONAL(RMT_ENABLED, _rmt_EndCPUSample())
 
+// Struture to fill in to modify Remotery default settings
+typedef struct rmtSettings
+{
+	rmtU32 port;
+	rmtU32 msSleepBetweenServerUpdates;
+	rmtU32 messageQueueSizeInBytes;
+	rmtU32 maxNbMessagesPerUpdate;
+	rmtPStr logFilename;
+} rmtSettings;
 
 // Structure to fill in when binding CUDA to Remotery
 typedef struct rmtCUDABind
@@ -436,7 +445,8 @@ struct rmt_EndOpenGLSampleOnScopeExit
 extern "C" {
 #endif
 
-enum rmtError _rmt_CreateGlobalInstance(Remotery** remotery, int port);
+rmtSettings* _rmt_Settings( void );
+enum rmtError _rmt_CreateGlobalInstance(Remotery** remotery);
 void _rmt_DestroyGlobalInstance(Remotery* remotery);
 void _rmt_SetGlobalInstance(Remotery* remotery);
 Remotery* _rmt_GetGlobalInstance(void);

--- a/lib/Remotery.h
+++ b/lib/Remotery.h
@@ -237,7 +237,7 @@ typedef enum rmtError
 // TODO: Can embed extern "C" in these macros?
 
 #define rmt_Settings()																\
-	RMT_OPTIONAL_RET(RMT_ENABLED, _rmt_Settings(), NULL )
+    RMT_OPTIONAL_RET(RMT_ENABLED, _rmt_Settings(), NULL )
 
 #define rmt_CreateGlobalInstance(rmt)                                               \
     RMT_OPTIONAL_RET(RMT_ENABLED, _rmt_CreateGlobalInstance(rmt), RMT_ERROR_NONE)
@@ -266,16 +266,21 @@ typedef enum rmtError
 #define rmt_EndCPUSample()                                                          \
     RMT_OPTIONAL(RMT_ENABLED, _rmt_EndCPUSample())
 
+// Memory allocation functions
+typedef void* (*rmtMallocPtr )(void* mm_context, rmtU32 size);
+typedef void(*rmtFreePtr)(void* mm_context, void* ptr);
+
 // Struture to fill in to modify Remotery default settings
 typedef struct rmtSettings
 {
-	rmtU32 port;
-	rmtU32 msSleepBetweenServerUpdates;
-	rmtU32 messageQueueSizeInBytes;
-	rmtU32 maxNbMessagesPerUpdate;
-	void* (*malloc)(size_t);
-	void (*free)();
-	rmtPStr logFilename;
+    rmtU32 port;
+    rmtU32 msSleepBetweenServerUpdates;
+    rmtU32 messageQueueSizeInBytes;
+    rmtU32 maxNbMessagesPerUpdate;
+    rmtMallocPtr malloc;
+    rmtFreePtr free;
+    void* mm_context;
+    rmtPStr logFilename;
 } rmtSettings;
 
 // Structure to fill in when binding CUDA to Remotery

--- a/lib/Remotery.h
+++ b/lib/Remotery.h
@@ -273,6 +273,8 @@ typedef struct rmtSettings
 	rmtU32 msSleepBetweenServerUpdates;
 	rmtU32 messageQueueSizeInBytes;
 	rmtU32 maxNbMessagesPerUpdate;
+	void* (*malloc)(size_t);
+	void (*free)();
 	rmtPStr logFilename;
 } rmtSettings;
 


### PR DESCRIPTION
Allow the user to specify the server port when creating a Remotery global instance. Allows a user to run multiple instances of a program on the same computer and view it in Remotery or deal with port conflicts.