### PR TITLE
Slightly nicer default thread naming as ThreadN where N is hex thread number. Fixes #40

### DIFF
--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -214,7 +214,7 @@ rmtS64 maxS64(rmtS64 a, rmtS64 b)
 // Memory management functions
 static void* rmtMalloc( rmtU32 size )
 {
-	return g_Settings.malloc( g_Settings.mm_context, size );
+    return g_Settings.malloc( g_Settings.mm_context, size );
 }
 
 static void* rmtRealloc( void* ptr, rmtU32 size)
@@ -224,7 +224,7 @@ static void* rmtRealloc( void* ptr, rmtU32 size)
 
 static void rmtFree( void* ptr )
 {
-	g_Settings.free( g_Settings.mm_context, ptr );
+    g_Settings.free( g_Settings.mm_context, ptr );
 }
 
 /*
@@ -1292,34 +1292,34 @@ static const char* hex_encoding_table = "0123456789ABCDEF";
 
 static void itoahex_s( char *dest, rsize_t dmax, rmtS32 value )
 {
-	rsize_t len;
-	rmtS32	halfbytepos;
+    rsize_t len;
+    rmtS32	halfbytepos;
 
-	halfbytepos = 8;
+    halfbytepos = 8;
 
-	/* strip leading 0's */
-	while (halfbytepos > 1)
-	{
-		--halfbytepos;
-		if (value >> (4 * halfbytepos) & 0xF)
-		{
-			++halfbytepos;
-			break;
-		}
-	}
+    /* strip leading 0's */
+    while (halfbytepos > 1)
+    {
+        --halfbytepos;
+        if (value >> (4 * halfbytepos) & 0xF)
+        {
+            ++halfbytepos;
+            break;
+        }
+    }
 
-	len = 0;
-	while(len + 1 < dmax && halfbytepos > 0)
-	{
-		--halfbytepos;
-		dest[len] = hex_encoding_table[value >> (4 * halfbytepos) & 0xF];
-		++len;
-	}
+    len = 0;
+    while(len + 1 < dmax && halfbytepos > 0)
+    {
+        --halfbytepos;
+        dest[len] = hex_encoding_table[value >> (4 * halfbytepos) & 0xF];
+        ++len;
+    }
 
-	if (len < dmax)
-	{
-		dest[len] = 0;
-	}
+    if (len < dmax)
+    {
+        dest[len] = 0;
+    }
 }
 
 
@@ -3674,9 +3674,9 @@ static rmtError ThreadSampler_Constructor(ThreadSampler* thread_sampler)
     thread_sampler->next = NULL;
 
     // Set the initial name to Thread0 etc.
-	thread_sampler->name[0] = 0;
-	strncat_s(thread_sampler->name, sizeof(thread_sampler->name), "Thread", 6);
-	itoahex_s(thread_sampler->name + 6, sizeof(thread_sampler->name) - 6, AtomicAdd(&countThreads, 1));
+    thread_sampler->name[0] = 0;
+    strncat_s(thread_sampler->name, sizeof(thread_sampler->name), "Thread", 6);
+    itoahex_s(thread_sampler->name + 6, sizeof(thread_sampler->name) - 6, AtomicAdd(&countThreads, 1));
 
     // Create the CPU sample tree only - the rest are created on-demand as they need
     // extra context information to function correctly.
@@ -4211,7 +4211,7 @@ static rmtError Remotery_GetThreadSampler(Remotery* rmt, ThreadSampler** thread_
         if (error != RMT_ERROR_NONE)
             return error;
         ts = *thread_sampler;
-		//printf("TS name: %s\n", ts->name);
+ 
         // Add to the beginning of the global linked list of thread samplers
         while (1)
         {

--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -468,12 +468,12 @@ static rmtBool AtomicCompareAndSwapPointer(long* volatile* ptr, long* old_ptr, l
 // TODO: Make sure all platforms don't insert a memory barrier as this is only for stats
 //       Alternatively, add strong/weak memory order equivalents
 //
-static void AtomicAdd(rmtS32 volatile* value, rmtS32 add)
+static rmtS32 AtomicAdd(rmtS32 volatile* value, rmtS32 add)
 {
     #if defined(RMT_PLATFORM_WINDOWS) && !defined(__MINGW32__)
-        _InterlockedExchangeAdd((long volatile*)value, (long)add);
+        return _InterlockedExchangeAdd((long volatile*)value, (long)add);
     #elif defined(RMT_PLATFORM_POSIX) || defined(__MINGW32__)
-        __sync_fetch_and_add(value, add);
+        return __sync_fetch_and_add(value, add);
     #endif
 }
 

--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -1287,6 +1287,42 @@ strncat_s (char *dest, rsize_t dmax, const char *src, rsize_t slen)
 
 
 
+/* very simple integer to hex */
+static const char* hex_encoding_table = "0123456789ABCDEF";
+
+static void itoahex_s( char *dest, rsize_t dmax, rmtS32 value )
+{
+	rsize_t len;
+	rmtS32	halfbytepos;
+
+	halfbytepos = 8;
+
+	/* strip leading 0's */
+	while (halfbytepos > 1)
+	{
+		--halfbytepos;
+		if (value >> (4 * halfbytepos) & 0xF)
+		{
+			++halfbytepos;
+			break;
+		}
+	}
+
+	len = 0;
+	while(len + 1 < dmax && halfbytepos > 0)
+	{
+		--halfbytepos;
+		dest[len] = hex_encoding_table[value >> (4 * halfbytepos) & 0xF];
+		++len;
+	}
+
+	if (len < dmax)
+	{
+		dest[len] = 0;
+	}
+}
+
+
 /*
 ------------------------------------------------------------------------------------------------------------------------
 ------------------------------------------------------------------------------------------------------------------------
@@ -3623,6 +3659,7 @@ typedef struct ThreadSampler
 
 } ThreadSampler;
 
+static rmtS32 countThreads = 0;
 
 static rmtError ThreadSampler_Constructor(ThreadSampler* thread_sampler)
 {
@@ -3636,8 +3673,10 @@ static rmtError ThreadSampler_Constructor(ThreadSampler* thread_sampler)
         thread_sampler->sample_trees[i] = NULL; 
     thread_sampler->next = NULL;
 
-    // Set the initial name based on the unique thread sampler address
-    Base64_Encode((rmtU8*)&thread_sampler, sizeof(rmtU8*), (rmtU8*)thread_sampler->name);
+    // Set the initial name to Thread0 etc.
+	thread_sampler->name[0] = 0;
+	strncat_s(thread_sampler->name, sizeof(thread_sampler->name), "Thread", 6);
+	itoahex_s(thread_sampler->name + 6, sizeof(thread_sampler->name) - 6, AtomicAdd(&countThreads, 1));
 
     // Create the CPU sample tree only - the rest are created on-demand as they need
     // extra context information to function correctly.
@@ -4172,7 +4211,7 @@ static rmtError Remotery_GetThreadSampler(Remotery* rmt, ThreadSampler** thread_
         if (error != RMT_ERROR_NONE)
             return error;
         ts = *thread_sampler;
-
+		//printf("TS name: %s\n", ts->name);
         // Add to the beginning of the global linked list of thread samplers
         while (1)
         {


### PR DESCRIPTION
I've not completely followed the prior string function source code method as this doesn't return an error, however the actual calls don't seem to use that so I think this is sufficient.