### PR TITLE
Use prctl with PR_GET_NAME to get the thread name in Linux.

### DIFF
--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -4386,8 +4386,8 @@ static void SetDebuggerThreadName(const char* name)
     #ifdef RMT_PLATFORM_POSIX
         // pthread_setname_np is a non-standard GNU extension.
         char name_clamp[16];
-        strncpy(name_clamp, name, 15);
-        name_clamp[15] = 0;
+        name_clamp[0] = 0;
+        strncat_s(name_clamp, sizeof(name_clamp), name, 15);
         prctl(PR_SET_NAME,name_clamp,0,0,0);
     #endif
 }

--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -3665,7 +3665,7 @@ static rmtError ThreadSampler_Constructor(ThreadSampler* thread_sampler)
         thread_sampler->sample_trees[i] = NULL;
     thread_sampler->next = NULL;
 
-    // Set the initial name to Thread0 etc. or use the existing POXIS name.
+    // Set the initial name to Thread0 etc. or use the existing POSIX name.
     thread_sampler->name[0] = 0;
     #if defined(RMT_PLATFORM_POSIX) && RMT_USE_POSIX_THREADNAMES
     prctl(PR_GET_NAME,thread_sampler->name,0,0,0);

--- a/lib/Remotery.h
+++ b/lib/Remotery.h
@@ -67,6 +67,11 @@ documented just below this comment.
 #define RMT_USE_OPENGL 0
 #endif
 
+// Initially use POSIX thread names to name threads instead of Thread0, 1, ...
+#ifndef RMT_USE_POSIX_THREADNAMES
+#define RMT_USE_POSIX_THREADNAMES 0
+#endif
+
 
 /*
 ------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
You can now use Remotery to get and set thread names in linux.

These names can be viewed on the Remotery profiler webpage, as well as Linux system inspection tools (for example, htop).

Due to system implementation, the name is restricted to 15 characters, plus the null terminating character \0.