### PR TITLE
Removed 'unused varaible' warning for countThreads

### DIFF
--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -3750,8 +3750,6 @@ typedef struct ThreadSampler
 
 } ThreadSampler;
 
-static rmtS32 countThreads = 0;
-
 static rmtError ThreadSampler_Constructor(ThreadSampler* thread_sampler)
 {
     rmtError error;
@@ -3769,6 +3767,7 @@ static rmtError ThreadSampler_Constructor(ThreadSampler* thread_sampler)
     #if defined(RMT_PLATFORM_LINUX) && RMT_USE_POSIX_THREADNAMES
     prctl(PR_GET_NAME,thread_sampler->name,0,0,0);
     #else
+    static rmtS32 countThreads = 0;
     strncat_s(thread_sampler->name, sizeof(thread_sampler->name), "Thread", 6);
     itoahex_s(thread_sampler->name + 6, sizeof(thread_sampler->name) - 6, AtomicAdd(&countThreads, 1));
     #endif


### PR DESCRIPTION
Removed 'unused varaible' warning for countThreads when building with RMT_USE_POSIX_THREADNAMES.