### PR TITLE
Fixed a small error that should not appear in C code.

### DIFF
--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -2143,7 +2143,7 @@ static rmtError TCPSocket_RunServer(TCPSocket* tcp_socket, rmtU16 port, rmtBool 
     sin.sin_family = AF_INET;
     sin.sin_addr.s_addr = htonl(limit_connections_to_localhost ? INADDR_LOOPBACK : INADDR_ANY);
     sin.sin_port = htons(port);
-    if (::bind(s, (struct sockaddr*)&sin, sizeof(sin)) == SOCKET_ERROR)
+    if (bind(s, (struct sockaddr*)&sin, sizeof(sin)) == SOCKET_ERROR)
         return RMT_ERROR_SOCKET_BIND_FAIL;
 
     // Connection is valid, remaining code is socket state modification


### PR DESCRIPTION
I know this has been solved in other pull requests (namely #98 and #96), however those are grouped together with other fixes. This fixes the `::bind` error that we've all been getting for once and it'll merge just fine. Also, even if you mark this as a duplicate, at least to the favor of merging one of the other pull requests.