### PR TITLE
Fixed the comparison warning.

### DIFF
--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -1918,7 +1918,7 @@ static rmtError HashTable_Resize(HashTable* table)
     for (rmtU32 i = 0; i < old_max_nb_slots; i++)
     {
         HashSlot* slot = old_slots + i;
-        if (slot->key != NULL)
+        if (slot)
             HashTable_Insert(table, slot->key, slot->key);
     }
 


### PR DESCRIPTION
Here's the second fix. There's this annoying warning that turns into an error when you have a strict compiler. Someone else tried fixing it, but I don't believe they did it correctly. We're not necessarily trying to see if `slot->key` is `0`, but rather if the pointer (`slot`) exists to begin with, 'cause since `slot->key` is stack allocated, if `slot` exists then so will `key`. So, we check if `slot` exists.