### PR TITLE
add support for FreeBSD

### DIFF
--- a/lib/Remotery.h
+++ b/lib/Remotery.h
@@ -90,7 +90,7 @@ documented just below this comment.
 // Platform identification
 #if defined(_WINDOWS) || defined(_WIN32)
     #define RMT_PLATFORM_WINDOWS
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__FreeBSD__)
     #define RMT_PLATFORM_LINUX
     #define RMT_PLATFORM_POSIX
 #elif defined(__APPLE__)


### PR DESCRIPTION
Here are some tweaks to make Remotery compile and work on FreeBSD.

FreeBSD's APIs are pretty similar to Linux, so I just based it on RMT_PLATFORM_LINUX.

The differences are:

* No malloc.h

* CLOCKS_PER_SEC is only 128. The comment next to msTimer_Get() seems to imply this resolution is sufficient, so I just avoided the division by zero in `time / (CLOCKS_PER_SEC / 1000)`. Another option is getrusage().

* No /dev/shm

* No prctl(). Thread name can be set with pthread_set_name_np() (and gdb sees it) but there's no function to get the name.

I tested profiling CPU and OpenGL with multiple threads. Seems to work fine.
