### PR TITLE
Console fixes

### DIFF
--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -4764,12 +4764,13 @@ static rmtError Remotery_ReceiveMessage(void* context, char* message_data, rmtU3
     {
         case FOURCC('C', 'O', 'N', 'I'):
         {
+            rmt_LogText("Console message received...");
+            rmt_LogText(message_data + 4);
+
             // Pass on to any registered handler
             if (g_Settings.input_handler != NULL)
                 g_Settings.input_handler(message_data + 4, g_Settings.input_handler_context);
 
-            rmt_LogText("Console message received...");
-            rmt_LogText(message_data + 4);
             break;
         }
 
@@ -5184,6 +5185,7 @@ static rmtBool QueueLine(rmtMessageQueue* queue, unsigned char* text, rmtU32 siz
 
     return RMT_TRUE;
 }
+
 
 RMT_API void _rmt_LogText(rmtPStr text)
 {

--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -5185,7 +5185,6 @@ static rmtBool QueueLine(rmtMessageQueue* queue, unsigned char* text, rmtU32 siz
     return RMT_TRUE;
 }
 
-
 RMT_API void _rmt_LogText(rmtPStr text)
 {
     int start_offset, prev_offset, i;
@@ -5211,7 +5210,7 @@ RMT_API void _rmt_LogText(rmtPStr text)
         char c = text[i];
 
         // Line wrap when too long or newline encountered
-        if (prev_offset == sizeof(line_buffer) - 3 || c == '\n')
+        if (prev_offset >= (int)sizeof(line_buffer) - 3 || c == '\n')
         {
             if (QueueLine(g_Remotery->mq_to_rmt_thread, line_buffer, prev_offset, ts) == RMT_FALSE)
                 return;
@@ -5248,7 +5247,7 @@ RMT_API void _rmt_LogText(rmtPStr text)
     // Send the last line
     if (prev_offset > start_offset)
     {
-        assert(prev_offset < ((int)sizeof(line_buffer) - 3));
+        assert(prev_offset <= (int)sizeof(line_buffer) - 2);
         QueueLine(g_Remotery->mq_to_rmt_thread, line_buffer, prev_offset, ts);
     }
 }

--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -5210,38 +5210,19 @@ RMT_API void _rmt_LogText(rmtPStr text)
         char c = text[i];
 
         // Line wrap when too long or newline encountered
-        if (offset >= (int)sizeof(line_buffer) - 1 || c == '\n')
+        if (offset == sizeof(line_buffer) || c == '\n')
         {
             if (QueueLine(g_Remotery->mq_to_rmt_thread, line_buffer, offset, ts) == RMT_FALSE)
                 return;
 
             // Restart line
             offset = start_offset;
+
+            if (c == '\n')
+                continue;
         }
 
-        // Safe to insert 2 characters here as previous check would split lines if not enough space left
-        switch (c)
-        {
-            // Skip newline, dealt with above
-            case '\n':
-                break;
-
-            // Escape these
-            case '\\':
-                line_buffer[offset++] = '\\';
-                line_buffer[offset++] = '\\';
-                break;
-
-            case '\"':
-                line_buffer[offset++] = '\\';
-                line_buffer[offset++] = '\"';
-                break;
-
-            // Add the rest
-            default:
-                line_buffer[offset++] = c;
-                break;
-        }
+        line_buffer[offset++] = c;
     }
 
     // Send the last line

--- a/readme.md
+++ b/readme.md
@@ -231,5 +231,7 @@ Some important settings are:
 
     // Specify an input handler that receives text input from the Remotery console, with an additional
     // context pointer that gets passed to your callback.
+    // The handler will be called from the Remotery thread so synchronization with a mutex or atomics
+    // might be needed to avoid race conditions with your threads.
     settings->input_handler;
     settings->input_handler_context;

--- a/vis/Code/Console.js
+++ b/vis/Code/Console.js
@@ -19,9 +19,9 @@ Console = (function()
 
 		// This accumulates log text as fast as is required
 		this.PageTextBuffer = "";
-		this.LastPageTextBufferLen = 0;
+		this.PageTextUpdatePending = false;
 		this.AppTextBuffer = "";
-		this.LastAppTextBufferLen = 0;
+		this.AppTextUpdatePending = false;
 
 		// Setup command history control
 		this.CommandHistory = LocalStore.Get("App", "Global", "CommandHistory", [ ]);
@@ -43,6 +43,7 @@ Console = (function()
 	Console.prototype.Log = function(text)
 	{
 		this.PageTextBuffer = LogText(this.PageTextBuffer, text);
+		this.PageTextUpdatePending = true;
 	}
 
 
@@ -67,9 +68,10 @@ Console = (function()
 
 	function OnLog(self, socket, data_view)
 	{
-	    var data_view_reader = new DataViewReader(data_view, 4);
-	    var text = data_view_reader.GetString();
-	    self.AppTextBuffer = LogText(self.AppTextBuffer, text);
+		var data_view_reader = new DataViewReader(data_view, 4);
+		var text = data_view_reader.GetString();
+		self.AppTextBuffer = LogText(self.AppTextBuffer, text);
+		self.AppTextUpdatePending = true;
 	}
 
 
@@ -102,20 +104,20 @@ Console = (function()
 	{
 		// Reset the current text buffer as html
 
-		if (self.LastPageTextBufferLen != self.PageTextBuffer.length)
+		if (self.PageTextUpdatePending)
 		{
 			var page_node = self.PageContainer.Node;
 			page_node.innerHTML = self.PageTextBuffer;
 			page_node.scrollTop = page_node.scrollHeight;
-			self.LastPageTextBufferLen = self.PageTextBuffer.length;
+			self.PageTextUpdatePending = false;
 		}
 
-		if (self.LastAppTextBufferLen != self.AppTextBuffer.length)
-		{		
+		if (self.AppTextUpdatePending)
+		{
 			var app_node = self.AppContainer.Node;
 			app_node.innerHTML = self.AppTextBuffer;
 			app_node.scrollTop = app_node.scrollHeight;
-			self.LastAppTextBufferLen = self.AppTextBuffer.length;
+			self.AppTextPending = false;
 		}
 	}
 

--- a/vis/Code/Console.js
+++ b/vis/Code/Console.js
@@ -117,7 +117,7 @@ Console = (function()
 			var app_node = self.AppContainer.Node;
 			app_node.innerHTML = self.AppTextBuffer;
 			app_node.scrollTop = app_node.scrollHeight;
-			self.AppTextPending = false;
+			self.AppTextUpdatePending = false;
 		}
 	}
 


### PR DESCRIPTION
I integrated Remotery into my project and made use of the console feature.
* Then I realized that somehow after a while there are no new messages displayed in the Remotery console window. I saw that after 10*1024 characters the viewer crops the beginning of the string. However, this means the size of the string remains the same but the size was the criterion to determine if a html update is needed. So I changed the update trigger.
* During debugging I also noticed that there is a buffer overrun that causes a stack corruption when calling `rmt_LogText()` with \ or " at the "right" location near line_buffer end. Calling `rmt_LogText("\\\\\\.......<many \\'s here>....\\\\")` will trigger this crash for example. In line 5214 `prev_offset` will be `sizeof(line_buffer) - 4` at some point. Then is will be increased by two (because of the \ --> \\\\ conversion) and in the next iteration `prev_offset` is `sizeof(line_buffer) - 2` and we will still not enter the if-body. The fix is simple, just use `>=` instead of `==`.
* However, is escaping \ and " in the string needed at all? I don't think so and thus removed it, or do I miss something?
* Additionally moved the logging of "Console message received..." and the actual message to the place before calling the input handler. Because if the input handler also logs something the order is somewhat wrong, e.g. after sending "loadgame('something.sav')" in the console window:
    * "loadgame('something.sav') called"
    * "loading game..."
    * "Console message received..."
    * "loadgame('something.sav')"