### PR TITLE
Fixed compile warnings when using Clang on Windows

### DIFF
--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -495,10 +495,10 @@ static void AtomicSub(rmtS32 volatile* value, rmtS32 sub)
 // Compiler write fences
 static void WriteFence()
 {
-#if defined(RMT_PLATFORM_WINDOWS) && !defined(__MINGW32__) && !defined(__clang__)
-    _WriteBarrier();
-#elif defined (__clang__)
+#if defined (__clang__)
     __asm__ volatile("" : : : "memory");
+#elif defined(RMT_PLATFORM_WINDOWS) && !defined(__MINGW32__)
+    _WriteBarrier();
 #else
     asm volatile ("" : : : "memory");
 #endif

--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -139,7 +139,7 @@ static rmtBool g_SettingsInitialized = RMT_FALSE;
 
 #endif
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
     #define RMT_UNREFERENCED_PARAMETER(i) (i)
 #else
     #define RMT_UNREFERENCED_PARAMETER(i) (void)(1 ? (void)0 : ((void)i))
@@ -495,7 +495,7 @@ static void AtomicSub(rmtS32 volatile* value, rmtS32 sub)
 // Compiler write fences
 static void WriteFence()
 {
-#if defined(RMT_PLATFORM_WINDOWS) && !defined(__MINGW32__)
+#if defined(RMT_PLATFORM_WINDOWS) && !defined(__MINGW32__) && !defined(__clang__)
     _WriteBarrier();
 #elif defined (__clang__)
     __asm__ volatile("" : : : "memory");


### PR DESCRIPTION
this pull request fixes these warnings generated when using Clang on Windows:



><snip>\Src\Remotery\lib\Remotery.c(500): warning : '_WriteBarrier' is deprecated: use other intrinsics or C++11 atomics instead [-Wdeprecated-declarations]
2>C:\Program Files\LLVM\lib\clang\6.0.1\include\intrin.h(209):  note: '_WriteBarrier' has been explicitly marked deprecated here
2><snip>\Remotery\lib\Remotery.c(663): warning : expression result unused [-Wunused-value]
2><snip>\Src\Remotery\lib\Remotery.c(144):  note: expanded from macro 'RMT_UNREFERENCED_PARAMETER'
2><snip>\Src\Remotery\lib\Remotery.c(3943): warning : expression result unused [-Wunused-value]
2><snip>\Src\Remotery\lib\Remotery.c(144):  note: expanded from macro 'RMT_UNREFERENCED_PARAMETER'
2><snip>\Src\Remotery\lib\Remotery.c(5021): warning : expression result unused [-Wunused-value]
2><snip>\Src\Remotery\lib\Remotery.c(144):  note: expanded from macro 'RMT_UNREFERENCED_PARAMETER'
2><snip>\Src\Remotery\lib\Remotery.c(5028): warning : expression result unused [-Wunused-value]
2><snip>\Src\Remotery\lib\Remotery.c(144):  note: expanded from macro 'RMT_UNREFERENCED_PARAMETER'
2><snip>\Src\Remotery\lib\Remotery.c(5034): warning : expression result unused [-Wunused-value]
2><snip>\Src\Remotery\lib\Remotery.c(144):  note: expanded from macro 'RMT_UNREFERENCED_PARAMETER'

