### PR TITLE
Adjust rsize_t check for MinGW-w64

### DIFF
--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -1167,7 +1167,7 @@ static void rmtThread_Destructor(rmtThread* thread)
 typedef int errno_t;
 #endif
 
-#if (!defined(_WIN64) && !defined(__APPLE__)) || (defined(__MINGW32__) && !defined(RSIZE_T_DEFINED))
+#if (!defined(_WIN64) && !defined(__APPLE__)) || (defined(__MINGW32__) && !(defined(RSIZE_T_DEFINED) || defined(_RSIZE_T_DEFINED)))
 typedef unsigned int rsize_t;
 #endif
 


### PR DESCRIPTION
In MinGW-w64 version 6, `crtdefs.h` defines `rsize_t` as `size_t`, but it defines `_RSIZE_T_DEFINED` instead of `RSIZE_T_DEFINED`.  It's possible that other MinGW distributions (e.g. older MinGW-w64, the original MinGW) define `RSIZE_T_DEFINED`, so this commit modifies the `rsize_t` check to consider both possibilities if `__MINGW32__` is set.