### PR TITLE
Do not define rsize_t on FreeBSD

### DIFF
--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -1167,7 +1167,7 @@ static void rmtThread_Destructor(rmtThread* thread)
 typedef int errno_t;
 #endif
 
-#if (!defined(_WIN64) && !defined(__APPLE__)) || (defined(__MINGW32__) && !(defined(RSIZE_T_DEFINED) || defined(_RSIZE_T_DEFINED)))
+#if (!defined(_WIN64) && !defined(__APPLE__) && !defined(__FreeBSD__)) || (defined(__MINGW32__) && !(defined(RSIZE_T_DEFINED) || defined(_RSIZE_T_DEFINED)))
 typedef unsigned int rsize_t;
 #endif
 


### PR DESCRIPTION
It is already defined in string.h and leads to a compilation error.