### PR TITLE
Fix D3D11 sampling self length

### DIFF
--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -6180,6 +6180,12 @@ static rmtBool GetD3D11SampleTimes(Sample* sample, rmtU64* out_first_timestamp, 
         sample->us_length = sample->us_end - sample->us_start;
     }
 
+    // Sum length on the parent to track un-sampled time in the parent
+    if (sample->parent != NULL)
+    {
+        sample->parent->us_sampled_length += sample->us_length;
+    }
+
     // Get child sample times
     for (child = sample->first_child; child != NULL; child = child->next_sibling)
     {

--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -5347,7 +5347,7 @@ static void Remotery_BlockingDeleteSampleTree(Remotery* rmt, enum SampleType sam
         {
             // Wait around until the Remotery server thread has sent all sample trees
             // of this type to the client
-            while (Server_IsClientConnected(rmt->server) && sample_tree->allocator->nb_inuse > 1)
+            while (sample_tree->allocator->nb_inuse > 1)
                 msSleep(1);
 
             // Now free to delete

--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -5347,7 +5347,7 @@ static void Remotery_BlockingDeleteSampleTree(Remotery* rmt, enum SampleType sam
         {
             // Wait around until the Remotery server thread has sent all sample trees
             // of this type to the client
-            while (sample_tree->allocator->nb_inuse > 1)
+            while (Server_IsClientConnected(rmt->server) && sample_tree->allocator->nb_inuse > 1)
                 msSleep(1);
 
             // Now free to delete


### PR DESCRIPTION
Hi

Thanks for your works =)

Allow me to go straight to the point.
I had two issues: 
 - wrong self length for gpu sampling
 - infinite stall when unbinding D3D11

The fix for self length is simple and obvious but maybe it's not the case for the stall fix.
