### PR TITLE
Bugreport with quick workaround for race condition/read access violation. 

### DIFF
--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -1,4 +1,5 @@
 //
+//
 // Copyright 2014-2018 Celtoys Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -4295,8 +4296,16 @@ typedef struct Msg_SampleTree
 } Msg_SampleTree;
 
 
+#ifdef SAMPLETREE_CAPTURE
+static void AddSampleTreeMessageHook(rmtMessageQueue* queue, Sample* sample, ObjectAllocator* allocator, rmtPStr thread_name, struct ThreadSampler* thread_sampler);
+#endif
+
 static void AddSampleTreeMessage(rmtMessageQueue* queue, Sample* sample, ObjectAllocator* allocator, rmtPStr thread_name, struct ThreadSampler* thread_sampler)
 {
+    #ifdef SAMPLETREE_CAPTURE
+    AddSampleTreeMessageHook(queue, sample, allocator, thread_name, thread_sampler);
+    #endif
+
     Msg_SampleTree* payload;
 
     // Attempt to allocate a message for sending the tree to the viewer
@@ -4315,8 +4324,6 @@ static void AddSampleTreeMessage(rmtMessageQueue* queue, Sample* sample, ObjectA
     payload->thread_name = thread_name;
     rmtMessageQueue_CommitMessage(message, MsgID_SampleTree);
 }
-
-
 
 
 /*


### PR DESCRIPTION
The bug occurs in the following scenario, typically with many unique names being sampled (dynamic namings).

The profiled-thread calls **StringTable_Insert->Buffer_Write->Buffer_Grow** to insert a new name.
While at the same time the remotery-thread handles messages and calls **Remotery_ReceiveMessage->case GSMP**. Then the later accesses a buffer (the name string), which is currently being grown in the profiled thread and not in a defined state. Thus causing a memory access violation.

The proposed solution works practically all the time in all my scenarios. Though not guaranteed to work always. More changes or explicit synchronization would be needed therefore.