### PR TITLE
Fix compiler warning [-Wswitch]

### DIFF
--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -4738,6 +4738,9 @@ static rmtError Remotery_ConsumeMessageQueue(Remotery* rmt)
                 error = Remotery_SendSampleTreeMessage(rmt, message);
                 rmt_EndCPUSample();
                 break;
+
+            default:
+                break;
         }
 
         // Consume the message before reacting to any errors
@@ -4775,6 +4778,9 @@ static void Remotery_FlushMessageQueue(Remotery* rmt)
                 FreeSampleTree(sample_tree->root_sample, sample_tree->allocator);
                 break;
             }
+
+            default:
+                break;
         }
 
         rmtMessageQueue_ConsumeNextMessage(rmt->mq_to_rmt_thread, message);


### PR DESCRIPTION
This PR fixes the compiler warning:

    enumeration values 'MsgID_None' and 'MsgID_Force32Bits' not handled in switch [-Wswitch]

This warning appears in both GCC and clang (when compiling in C++ mode).

Note: "Remotery" generally has always compiled cleanly with zero warnings. The warning under discussion was introduced in this commit: <https://github.com/Celtoys/Remotery/commit/f80c5a3dda354204a47c2efcddab506a8031a4af>