### PR TITLE
[Viewer] Add window resizing

### DIFF
--- a/vis/Code/Console.js
+++ b/vis/Code/Console.js
@@ -37,6 +37,8 @@ Console = (function()
 		this.Server = server;
 		server.SetConsole(this);
 		server.AddMessageHandler("LOGM", Bind(OnLog, this));
+		
+		this.Window.SetOnResize(Bind(OnUserResize, this));
 	}
 
 
@@ -53,16 +55,7 @@ Console = (function()
 		this.Window.SetPosition(BORDER, height - BORDER - 200);
 		this.Window.SetSize(width - 2 * BORDER, HEIGHT);
 
-		// Place controls
-		var parent_size = this.Window.Size;
-		var mid_w = parent_size[0] / 3;
-		this.UserInput.SetPosition(BORDER, parent_size[1] - 2 * BORDER - 30);
-		this.UserInput.SetSize(parent_size[0] - 100, 18);
-		var output_height = this.UserInput.Position[1] - 2 * BORDER;
-		this.PageContainer.SetPosition(BORDER, BORDER);
-		this.PageContainer.SetSize(mid_w - 2 * BORDER, output_height);
-		this.AppContainer.SetPosition(mid_w, BORDER);
-		this.AppContainer.SetSize(parent_size[0] - mid_w - BORDER, output_height);
+		ResizeInternals(this);
 	}
 
 
@@ -97,6 +90,25 @@ Console = (function()
 			existing_text = existing_text.substr(len - max_len, max_len);
 
 		return existing_text;
+	}
+
+	function OnUserResize(self, evt)
+	{
+		ResizeInternals(self);
+	}
+
+	function ResizeInternals(self)
+	{
+		// Place controls
+		var parent_size = self.Window.Size;
+		var mid_w = parent_size[0] / 3;
+		self.UserInput.SetPosition(BORDER, parent_size[1] - 2 * BORDER - 30);
+		self.UserInput.SetSize(parent_size[0] - 100, 18);
+		var output_height = self.UserInput.Position[1] - 2 * BORDER;
+		self.PageContainer.SetPosition(BORDER, BORDER);
+		self.PageContainer.SetSize(mid_w - 2 * BORDER, output_height);
+		self.AppContainer.SetPosition(mid_w, BORDER);
+		self.AppContainer.SetSize(parent_size[0] - mid_w - BORDER, output_height);
 	}
 
 

--- a/vis/Code/SampleWindow.js
+++ b/vis/Code/SampleWindow.js
@@ -16,7 +16,7 @@ SampleWindow = (function()
         this.Visible = true;
 
         // Create a grid that's indexed by the unique sample ID
-        this.Grid = this.Window.AddControlNew(new WM.Grid(0, 0, 380, "calc( 100% - 17px )"));
+        this.Grid = this.Window.AddControlNew(new WM.Grid());
         var cell_data =
         {
             Name: "Samples",

--- a/vis/Code/TimelineWindow.js
+++ b/vis/Code/TimelineWindow.js
@@ -14,7 +14,6 @@ TimelineWindow = (function()
 
 	var box_template = "<div class='TimelineBox'></div>";
 
-
 	function TimelineWindow(wm, settings, server, check_handler)
 	{
 		this.Settings = settings;
@@ -45,6 +44,8 @@ TimelineWindow = (function()
 		this.TimeRange = new PixelTimeRange(0, 200 * 1000, RowWidth(this));
 
 		this.CheckHandler = check_handler;
+
+		this.Window.SetOnResize(Bind(OnUserResize, this));
 	}
 
 
@@ -59,30 +60,14 @@ TimelineWindow = (function()
 		this.OnSelectedHandler = handler;
 	}
 
-
 	TimelineWindow.prototype.WindowResized = function(width, height, top_window)
 	{
 		// Resize window
 		var top = top_window.Position[1] + top_window.Size[1] + 10;
 		this.Window.SetPosition(10, top);
-		this.Window.SetSize(width - 2 * 10, 200);
+		this.Window.SetSize(width - 2 * 10, 260);
 
-		// Resize controls
-		var parent_size = this.Window.Size;
-		this.TimelineContainer.SetPosition(BORDER, 10);
-		this.TimelineContainer.SetSize(parent_size[0] - 2 * BORDER, 160);
-
-		// Resize rows
-		var row_width = RowWidth(this);
-		for (var i in this.ThreadRows)
-		{
-			var row = this.ThreadRows[i];
-			row.SetSize(row_width);
-		}
-
-		// Adjust time range to new width
-		this.TimeRange.SetPixelSpan(row_width);
-		this.DrawAllRows();
+		ResizeInternals(this);
 	}
 
 
@@ -147,6 +132,26 @@ TimelineWindow = (function()
 		// Subtract sizing of the label
 		// TODO: Use computed size
 		return self.TimelineContainer.Size[0] - (ROW_START_SIZE + ROW_END_SIZE);
+	}
+
+	function ResizeInternals(self)
+	{
+		// Resize controls
+		var parent_size = self.Window.Size;
+		self.TimelineContainer.SetPosition(BORDER, 10);
+		self.TimelineContainer.SetSize(parent_size[0] - 2 * BORDER, parent_size[1] - 40);
+
+		// Resize rows
+		var row_width = RowWidth(self);
+		for (var i in self.ThreadRows)
+		{
+			var row = self.ThreadRows[i];
+			row.SetSize(row_width);
+		}
+
+		// Adjust time range to new width
+		self.TimeRange.SetPixelSpan(row_width);
+		self.DrawAllRows();
 	}
 
 
@@ -266,6 +271,11 @@ TimelineWindow = (function()
 		}
 
 		self.LastMouseState = mouse_state;
+	}
+
+	function OnUserResize(self, evt)
+	{
+		ResizeInternals(self);
 	}
 
 

--- a/vis/Code/TimelineWindow.js
+++ b/vis/Code/TimelineWindow.js
@@ -134,6 +134,11 @@ TimelineWindow = (function()
 		return self.TimelineContainer.Size[0] - (ROW_START_SIZE + ROW_END_SIZE);
 	}
 
+	function OnUserResize(self, evt)
+	{
+		ResizeInternals(self);
+	}
+
 	function ResizeInternals(self)
 	{
 		// Resize controls
@@ -271,11 +276,6 @@ TimelineWindow = (function()
 		}
 
 		self.LastMouseState = mouse_state;
-	}
-
-	function OnUserResize(self, evt)
-	{
-		ResizeInternals(self);
 	}
 
 

--- a/vis/Code/TitleWindow.js
+++ b/vis/Code/TitleWindow.js
@@ -18,6 +18,8 @@ TitleWindow = (function()
 		this.PauseButton.SetOnClick(Bind(OnPausePressed, this));
 
 		server.AddMessageHandler("PING", Bind(OnPing, this));
+		
+		this.Window.SetOnResize(Bind(OnUserResize, this));
 	}
 
 
@@ -30,7 +32,17 @@ TitleWindow = (function()
 	TitleWindow.prototype.WindowResized = function(width, height)
 	{
 		this.Window.SetSize(width - 2 * 10, 50);
-		this.PauseButton.SetPosition(width - 80, 5);
+		ResizeInternals(this);
+	}
+
+	function OnUserResize(self, evt)
+	{
+		ResizeInternals(self);
+	}
+
+	function ResizeInternals(self)
+	{
+		self.PauseButton.SetPosition(self.Window.Size[0] - 60, 5);
 	}
 
 

--- a/vis/extern/BrowserLib/WindowManager/Code/Grid.js
+++ b/vis/extern/BrowserLib/WindowManager/Code/Grid.js
@@ -210,22 +210,18 @@ WM.Grid = (function()
 		</div>";
 
 
-	function Grid(x, y, width, height)
+	function Grid()
 	{
 		this.Rows = new WM.GridRows(this);
 
 		this.Node = DOM.Node.CreateHTML(template_html);
 		this.BodyNode = DOM.Node.FindWithClass(this.Node, "GridBody");
 
-		DOM.Node.SetPosition(this.Node, [ x, y ]);
-		DOM.Node.SetSize(this.Node, [ width, height ]);
-
 		DOM.Event.AddHandler(this.Node, "dblclick", OnDblClick);
 
 		var mouse_wheel_event = (/Firefox/i.test(navigator.userAgent)) ? "DOMMouseScroll" : "mousewheel";
 		DOM.Event.AddHandler(this.Node, mouse_wheel_event, Bind(OnMouseScroll, this));
 	}
-
 
 	function OnDblClick(evt)
 	{

--- a/vis/extern/BrowserLib/WindowManager/Code/Window.js
+++ b/vis/extern/BrowserLib/WindowManager/Code/Window.js
@@ -8,7 +8,7 @@ WM.Window = (function()
 		<div class='Window'>
 			<div class='WindowTitleBar'>
 				<div class='WindowTitleBarText notextsel' style='float:left'>Window Title Bar</div>
-				<div class='WindowTitleBarClose notextsel' style='float:right'>O</div>
+				<div class='WindowTitleBarClose notextsel' style='float:right'>&#10005;</div>
 			</div>
 			<div class='WindowBody'>
 			</div>
@@ -84,9 +84,9 @@ WM.Window = (function()
 	}
 
 
-	Window.prototype.Hide = function()
+	Window.prototype.Hide = function(evt)
 	{
-		if (this.Node.parentNode == this.ParentNode)
+		if (this.Node.parentNode == this.ParentNode && evt.button == 0)
 		{
 			if (this.AnimatedShow)
 			{

--- a/vis/extern/BrowserLib/WindowManager/Code/Window.js
+++ b/vis/extern/BrowserLib/WindowManager/Code/Window.js
@@ -278,8 +278,8 @@ WM.Window = (function()
 
 	Window.prototype.SetSize = function(w, h)
 	{
-		w = (w < 80) ? 80 : w;
-		h = (h < 15) ? 15 : h;
+		w = Math.max(80, w);
+		h = Math.max(15, h);
 		this.Size = [ w, h ];
 		DOM.Node.SetSize(this.Node, this.Size);
 	}

--- a/vis/extern/BrowserLib/WindowManager/Styles/WindowManager.css
+++ b/vis/extern/BrowserLib/WindowManager/Styles/WindowManager.css
@@ -133,6 +133,17 @@ body
 	cursor: default;
 }
 
+.WindowResizeHandle 
+{
+    color: #999999;
+    font: 17px Verdana;
+    padding: 3px;
+    cursor: se-resize;
+    position: absolute;
+    bottom: -7px;
+    right: -3px;
+}
+
 .WindowBody
 {
 	/* Turns this node into a "positioned node" so that its children can be placed relative to it */

--- a/vis/extern/BrowserLib/WindowManager/Styles/WindowManager.css
+++ b/vis/extern/BrowserLib/WindowManager/Styles/WindowManager.css
@@ -144,22 +144,17 @@ body
     right: -3px;
 }
 
-.WindowBody
-{
-	/* Turns this node into a "positioned node" so that its children can be placed relative to it */
-	position: absolute;
-
-	/* Further clip stuff belonging to the body */
-	/*overflow: hidden;*/
-
-	/* Fill the parent window node */
-	/*width: calc(100% - 20px);
-	height: calc(100% - (20px + 17px + 2px));*/
-	width: 100%;
-	height: 100%;
-
-	padding:10px;
-	border-top: 1px solid #606060;
+.WindowBody {
+    position: absolute;
+    /* overflow: hidden; */
+    display: block;
+    padding: 10px;
+    border-top: 1px solid #606060;
+    top: 18px;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: auto;
 }
 
 
@@ -539,19 +534,11 @@ body
 /* ------------------------------------------------------------------------------------------------------------------ */
 
 
-
-.Grid
-{
-	/* Clip contents */
-	overflow: hidden;
-	overflow-y: auto;
-
-	/* TODO: SHOULD THIS BE ABSOLUTE? */
-	position: relative;
-
-	background: #333;
-
-	border-radius: 2px;
+.Grid {
+    overflow: auto;
+    background: #333;
+    height: 100%;
+    border-radius: 2px;
 }
 
 .GridBody

--- a/vis/extern/BrowserLib/WindowManager/Styles/WindowManager.css
+++ b/vis/extern/BrowserLib/WindowManager/Styles/WindowManager.css
@@ -133,6 +133,10 @@ body
 	cursor: default;
 }
 
+.WindowTitleBarClose:hover {
+    color: #bbb;
+}
+
 .WindowResizeHandle 
 {
     color: #999999;
@@ -633,7 +637,11 @@ body
 	box-shadow: 1px 1px 1px #222, 1px 1px 1px #777 inset;
 }
 
-.ButtonHeld
+.Button:hover {
+    background-color: #616161;
+}
+
+.Button.ButtonHeld
 {
 	/* Reset the gradient to a full-colour background */
 	background:#383838;


### PR DESCRIPTION
![rmt_resizing](https://user-images.githubusercontent.com/17261478/74062455-9e979600-49ee-11ea-917a-7c38278beeb9.jpg)

- Added handle to bottom left of windows allowing click-and-drag resizing
- Cleaned up some CSS positioning logic
- Changed the window hide button from "O" to a unicode multiplication ` x`
- Added subtle hover highlights to buttons and the window hide button
- Changed window hide to only occur on left-click and mouseup instead of mousedown

Note that windows still snap back into their default size and position when the browser resizes.