### PR TITLE
Thread id on nix

### DIFF
--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -1705,7 +1705,7 @@ static rmtThreadId rmtGetCurrentThreadId()
 #ifdef RMT_PLATFORM_WINDOWS
     return GetCurrentThreadId();
 #else
-    return pthread_self();
+    return (rmtThreadId)pthread_self();
 #endif
 }
 

--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -126,9 +126,6 @@ static rmtBool g_SettingsInitialized = RMT_FALSE;
             #include <pthread_np.h>
         #else
             #include <sys/prctl.h>
-            //On Linux we need to do a syscall to get the thread id.
-            #include <sys/types.h>
-            #include <sys/syscall.h>
         #endif
     #endif
 
@@ -1677,7 +1674,7 @@ static const char* itoa_s(rmtS32 value)
 ------------------------------------------------------------------------------------------------------------------------
 */
 
-typedef rmtU32 rmtThreadId;
+typedef rmtU64 rmtThreadId;
 
 #ifdef RMT_PLATFORM_WINDOWS
 typedef HANDLE rmtThreadHandle;
@@ -1708,12 +1705,7 @@ static rmtThreadId rmtGetCurrentThreadId()
 #ifdef RMT_PLATFORM_WINDOWS
     return GetCurrentThreadId();
 #else
-#elif defined(RMT_PLATFORM_POSIX)
-    #if defined(__FreeBSD__) || defined(__OpenBSD__)
-    return pthread_getthreadid_np();
-    #else
-    return syscall(__NR_gettid);
-    #endif
+    return pthread_self();
 #endif
 }
 

--- a/vis/Code/PixelTimeRange.js
+++ b/vis/Code/PixelTimeRange.js
@@ -55,13 +55,7 @@ class PixelTimeRange
 
 	SetAsUniform(gl, program)
 	{
-	    //Uniforms that aren't used by the shaders are commented out.
-        //This is because depending on the shader compiler unused uniforms might get optimized away, even if they are declared.
-        //When this happens there will be an error thrown as WebGL can't find the uniform.
-		//glSetUniform(gl, program, "inTimeRange.pxSpan", this.Span_px);
 		glSetUniform(gl, program, "inTimeRange.usStart", this.Start_us);
-		//glSetUniform(gl, program, "inTimeRange.usSpan", this.Span_us);
-		//glSetUniform(gl, program, "inTimeRange.usEnd", this.End_us);
 		glSetUniform(gl, program, "inTimeRange.usPerPixel", this.usPerPixel);
 	}
 }

--- a/vis/Code/PixelTimeRange.js
+++ b/vis/Code/PixelTimeRange.js
@@ -55,10 +55,13 @@ class PixelTimeRange
 
 	SetAsUniform(gl, program)
 	{
-		glSetUniform(gl, program, "inTimeRange.pxSpan", this.Span_px);
+	    //Uniforms that aren't used by the shaders are commented out.
+        //This is because depending on the shader compiler unused uniforms might get optimized away, even if they are declared.
+        //When this happens there will be an error thrown as WebGL can't find the uniform.
+		//glSetUniform(gl, program, "inTimeRange.pxSpan", this.Span_px);
 		glSetUniform(gl, program, "inTimeRange.usStart", this.Start_us);
-		glSetUniform(gl, program, "inTimeRange.usSpan", this.Span_us);
-		glSetUniform(gl, program, "inTimeRange.usEnd", this.End_us);
+		//glSetUniform(gl, program, "inTimeRange.usSpan", this.Span_us);
+		//glSetUniform(gl, program, "inTimeRange.usEnd", this.End_us);
 		glSetUniform(gl, program, "inTimeRange.usPerPixel", this.usPerPixel);
 	}
 }

--- a/vis/Code/Shaders.js
+++ b/vis/Code/Shaders.js
@@ -14,10 +14,7 @@ struct Viewport
 
 struct TimeRange
 {
-    float pxSpan;
     float usStart;
-    float usSpan;
-    float usEnd;
     float usPerPixel;
 };
 


### PR DESCRIPTION
This fixes an issue where all threads on *NIX always got the same profiler.
Apart from random crazyness there would often be an assert of "assert(sample != tree->root);" in SampleTree_Pop after a while as different threads popped and pushed samples to the same profiler.

Note that I've tested the thread id code on Linux, but not on OSX or FreeBSD.

In addition I fixed an issue with the shader code that made the frontend stop working on some machines.