### PR TITLE
Fix itoahex_s and itoa_s not defined when RMT_USE_POSIX_THREADNAMES=1

### DIFF
--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -1605,8 +1605,6 @@ errno_t strcpy_s(char* dest, r_size_t dmax, const char* src)
     return RCNEGATE(ESNOSPC);
 }
 
-#if !(defined(RMT_PLATFORM_LINUX) && RMT_USE_POSIX_THREADNAMES)
-
 /* very simple integer to hex */
 static const char* hex_encoding_table = "0123456789ABCDEF";
 
@@ -1663,8 +1661,6 @@ static const char* itoa_s(rmtS32 value)
 
     return temp_dest + pos + 1;
 }
-
-#endif
 
 /*
 ------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
See https://github.com/Celtoys/Remotery/issues/186