### PR TITLE
Add first proof of concept for rmt_StatI32

### DIFF
--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -4316,6 +4316,7 @@ typedef struct StatInfo
     enum rmtStatType type;
     union {
         rmtI32 ivalue;
+        rmtU32 uvalue;
         rmtF32 fvalue;
     } value;
     rmtU32 flags;
@@ -4476,12 +4477,20 @@ static void Sample_CopyState(Sample* dst_sample, const Sample* src_sample)
 
 static rmtError bin_SampleArray(Buffer* buffer, Sample* parent_sample);
 
+static const char* gStatTypeStrings[] = {
+    "I32",
+    "F32",
+    "TXT",
+    "NUL",
+};
+
 static rmtError bin_Sample(Buffer* buffer, Sample* sample)
 {
     rmtError error;
 
     assert(sample != NULL);
 
+    // For decoding, See Remotery.js : DecodeSample
     BIN_ERROR_CHECK(Buffer_WriteU32(buffer, sample->name_hash));
     BIN_ERROR_CHECK(Buffer_WriteU32(buffer, sample->unique_id));
     BIN_ERROR_CHECK(Buffer_Write(buffer, sample->unique_id_html_colour, 7));
@@ -4490,6 +4499,9 @@ static rmtError bin_Sample(Buffer* buffer, Sample* sample)
     BIN_ERROR_CHECK(Buffer_WriteU64(buffer, maxS64(sample->us_length - sample->us_sampled_length, 0)));
     BIN_ERROR_CHECK(Buffer_WriteU32(buffer, sample->call_count));
     BIN_ERROR_CHECK(Buffer_WriteU32(buffer, sample->max_recurse_depth));
+    BIN_ERROR_CHECK(Buffer_Write(buffer, gStatTypeStrings[sample->stat_info.type], 3));
+    BIN_ERROR_CHECK(Buffer_WriteU32(buffer, sample->stat_info.value.uvalue));
+    BIN_ERROR_CHECK(Buffer_WriteU32(buffer, sample->stat_info.desc));
     BIN_ERROR_CHECK(bin_SampleArray(buffer, sample));
 
     return RMT_ERROR_NONE;

--- a/lib/Remotery.h
+++ b/lib/Remotery.h
@@ -210,6 +210,8 @@ typedef unsigned char rmtU8;
 typedef unsigned short rmtU16;
 typedef unsigned int rmtU32;
 typedef unsigned long long rmtU64;
+typedef signed int rmtI32;
+typedef float rmtF32;
 
 
 // Signed integer types
@@ -316,6 +318,17 @@ typedef enum rmtSampleFlags
 } rmtSampleFlags;
 
 
+typedef enum rmtStatFlags
+{
+    // Default behaviour
+    RMT_Stat_None = 0,
+
+    // Counters are cleared each frame
+    RMT_Stat_Counter = 1,
+
+} rmtStatFlags;
+
+
 typedef enum rmtSampleType
 {
     RMT_SampleType_CPU,
@@ -323,8 +336,17 @@ typedef enum rmtSampleType
     RMT_SampleType_D3D11,
     RMT_SampleType_OpenGL,
     RMT_SampleType_Metal,
+    RMT_SampleType_Stat,
     RMT_SampleType_Count,
 } rmtSampleType;
+
+typedef enum rmtStatType
+{
+    RMT_StatType_I32,
+    RMT_StatType_F32,
+    RMT_StatType_Text,
+    RMT_StatType_Count,
+} rmtStatType;
 
 // Struct to hold iterator info
 typedef struct rmtSampleIterator
@@ -421,6 +443,21 @@ typedef struct rmtSampleIterator
 
 #define rmt_SampleGetType(sample)                                                   \
     RMT_OPTIONAL_RET(RMT_ENABLED, _rmt_SampleGetType(sample), RMT_SampleType_Count)
+
+#define rmt_SampleGetStatType(sample)                                                   \
+    RMT_OPTIONAL_RET(RMT_ENABLED, _rmt_SampleGetStatType(sample), RMT_StatType_Count)
+
+#define rmt_SampleGetStatDesc(sample)                                                   \
+    RMT_OPTIONAL_RET(RMT_ENABLED, _rmt_SampleGetStatDesc(sample), 0)
+
+#define rmt_SampleGetStatValueI32(sample)                                               \
+    RMT_OPTIONAL_RET(RMT_ENABLED, _rmt_SampleGetStatValueI32(sample), 0)
+
+#define rmt_StatI32(name, value, default_value, flags, desc)                            \
+    RMT_OPTIONAL(RMT_ENABLED, {                                                         \
+        static rmtU32 rmt_stat_hash_##name = 0;                                         \
+        _rmt_StatI32(#name, value, default_value, flags, desc, &rmt_stat_hash_##name);         \
+    })
 
 
 // Callback function pointer types
@@ -731,6 +768,10 @@ RMT_API void _rmt_BeginMetalSample(rmtPStr name, rmtU32* hash_cache);
 RMT_API void _rmt_EndMetalSample(void);
 #endif
 
+// Statistics
+RMT_API void _rmt_StatI32(const char* name, rmtI32 value, rmtI32 default_value, rmtU32 flags, const char* desc, rmtU32* hash_cache);
+
+
 // Iterator
 RMT_API void                _rmt_IterateChildren(rmtSampleIterator* iter, rmtSample* sample);
 RMT_API rmtBool             _rmt_IterateNext(rmtSampleIterator* iter);
@@ -748,6 +789,9 @@ RMT_API rmtU64              _rmt_SampleGetTime(rmtSample* sample);
 RMT_API rmtU64              _rmt_SampleGetSelfTime(rmtSample* sample);
 RMT_API void                _rmt_SampleGetColour(rmtSample* sample, rmtU8* r, rmtU8* g, rmtU8* b);
 RMT_API rmtSampleType       _rmt_SampleGetType(rmtSample* sample);
+RMT_API rmtStatType         _rmt_SampleGetStatType(rmtSample* sample);
+RMT_API rmtI32              _rmt_SampleGetStatValueI32(rmtSample* sample);
+RMT_API const char*         _rmt_SampleGetStatDesc(rmtSample* sample);
 
 #ifdef __cplusplus
 

--- a/sample/dump.c
+++ b/sample/dump.c
@@ -138,7 +138,7 @@ int main() {
     }
 
     rmt_StatDeclareGroupNoParent(Sample, "Top scope");
-    rmt_StatDeclareS32(AggregateCallCount, Sample, 7, RMT_StatOperation_Add, "Sums up all calls");
+    rmt_StatDeclareS32(AggregateCallCount, Sample, 0, RMT_StatOperation_Add, "Sums up all calls");
     rmt_StatDeclareS32(RecursiveCallDepth, Sample, 0, RMT_StatOperation_Set, "Shows the max depth");
 
     int max_count = 5;

--- a/sample/sample.c
+++ b/sample/sample.c
@@ -5,7 +5,8 @@
 #include "../lib/Remotery.h"
 
 void aggregateFunction() {
-    rmt_BeginCPUSample(aggregate, RMTSF_Aggregate);    
+    rmt_BeginCPUSample(aggregate, RMTSF_Aggregate);
+        rmt_StatI32(MyCounter, 1, 0, RMT_Stat_None, "test");
     rmt_EndCPUSample();
 }
 void recursiveFunction(int depth) {

--- a/vis/Code/DataViewReader.js
+++ b/vis/Code/DataViewReader.js
@@ -23,10 +23,24 @@ DataViewReader = (function ()
         return v;
     }
 
+    DataViewReader.prototype.GetInt32 = function ()
+    {
+        var v = this.DataView.getInt32(this.Offset, true);
+        this.Offset += 4;
+        return v;
+    }
+
     DataViewReader.prototype.GetUInt64 = function ()
     {
         var v = this.DataView.getFloat64(this.Offset, true);
         this.Offset += 8;
+        return v;
+    }
+
+    DataViewReader.prototype.GetFloat32 = function ()
+    {
+        var v = this.DataView.getFloat32(this.Offset, true);
+        this.Offset += 4;
         return v;
     }
 

--- a/vis/Code/Remotery.js
+++ b/vis/Code/Remotery.js
@@ -227,6 +227,27 @@ Remotery = (function()
         sample.us_self = data_view_reader.GetUInt64();
         sample.call_count = data_view_reader.GetUInt32();
         sample.recurse_depth = data_view_reader.GetUInt32();
+        sample.stat_type = data_view_reader.GetStringOfLength(3);
+        if (sample.stat_type == "I32")
+            sample.stat_value = data_view_reader.GetInt32();
+        else if (sample.stat_type == "F32")
+            sample.stat_value = data_view_reader.GetFloat32();
+        else {
+            data_view_reader.GetUInt32();
+            sample.stat_value = null;
+        }
+        sample.stat_desc_hash = data_view_reader.GetUInt32();
+        let [ desc_name_exists, desc_name ] = self.sampleNames.Get(sample.stat_desc_hash);
+        sample.stat_desc = desc_name;
+
+        // If the name doesn't exist in the map yet, request it from the server
+        if (!desc_name_exists)
+        {
+            if (self.Server.Connected())
+            {
+                self.Server.Send("GSMP" + sample.stat_desc_hash);
+            }
+        }
 
         // TODO(don): Get the profiler to pass these directly instead of hex colour
         const colour = parseInt(sample.colour.slice(1), 16);


### PR DESCRIPTION
The iterator example now outputs stats as well:
```
~/code/Remotery $ ./test
// ********************   DUMP TREE: Thread0   ************************
SAMPLE: delay 1  time: 12  self: 12 type: 0  color: 0xddf9f8
  SAMPLE: recursive 6  time: 0  self: 0 type: 0  color: 0x6e745f
  SAMPLE: aggregate 3  time: 0  self: 0 type: 0  color: 0xcfd6ff
    STAT: MyCounter type: RMT_StatType_I32 value: 3  desc: test
```

Also, here's a first screenshot of a statistic in action:
<img width="417" alt="Screenshot 2022-04-14 at 16 06 15" src="https://user-images.githubusercontent.com/1349334/163409678-b66180cc-4cd4-41cd-bded-057e3cf83379.png">

