### PR TITLE
Fix for ubsan warning when multiplying a negative value with an unsigned int

### DIFF
--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -3362,7 +3362,7 @@ static rmtU32 rotl32(rmtU32 x, rmtS8 r)
 static rmtU32 getblock32(const rmtU32* p, int i)
 {
     rmtU32 result;
-    const rmtU8* src = ((const rmtU8*)p) + i * sizeof(rmtU32);
+    const rmtU8* src = ((const rmtU8*)p) + i * (int)sizeof(rmtU32);
     memcpy(&result, src, sizeof(result));
     return result;
 }


### PR DESCRIPTION
When running the sample `dump.c` with UBSan, in complained about getblock32 used in the MurmurHash3_x86_32, which reads a block at index `-1`.

```
lib/Remotery.c:3365:42: runtime error: addition of unsigned offset to 0x7fe010008064 overflowed to 0x7fe010008060
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior lib/Remotery.c:3365:42 in 
```

Compiled with `clang -fsanitize=undefined -std=c89 -DRMT_ENABLED=1 -DRMT_ARCH_64BIT -g -O0 -Ilib sample/dump.c lib/Remotery.c -o test && ./test`
