### PR TITLE
Fixed return value in `_rmt_BeginMetalSample` declaration

### DIFF
--- a/lib/Remotery.h
+++ b/lib/Remotery.h
@@ -1059,7 +1059,7 @@ RMT_API void _rmt_EndOpenGLSample(void);
 #endif
 
 #if RMT_USE_METAL
-RMT_API void _rmt_BeginMetalSample(rmtPStr name, rmtU32* hash_cache);
+RMT_API rmtError _rmt_BeginMetalSample(rmtPStr name, rmtU32* hash_cache);
 RMT_API void _rmt_EndMetalSample(void);
 #endif
 


### PR DESCRIPTION
It seems that the [declaration](https://github.com/Celtoys/Remotery/blob/616fdf222a6b98f09de5e7fab167099dd92bef39/lib/Remotery.h#L1062) and [definition](https://github.com/Celtoys/Remotery/blob/616fdf222a6b98f09de5e7fab167099dd92bef39/lib/Remotery.c#L9757) of `_rmt_BeginMetalSample` are incompatible and fail to compile (when `RMT_USE_METAL` is on).