### PR TITLE
WIP: Vulkan sampling support

### DIFF
--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -189,6 +189,10 @@ static rmtBool g_SettingsInitialized = RMT_FALSE;
     #include <atomic>
 #endif
 
+#ifndef RMT_PLATFORM_WINDOWS
+    #define ZeroMemory(dest, len) memset(dest, 0, len)
+#endif
+
 // clang-format on
 
 #if defined(_MSC_VER) && !defined(__clang__)

--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -7098,12 +7098,6 @@ static void Remotery_Destructor(Remotery* rmt)
 
     rmtDelete(ThreadProfilers, rmt->threadProfilers);
 
-    if (g_RemoteryCreated)
-    {
-        g_Remotery = NULL;
-        g_RemoteryCreated = RMT_FALSE;
-    }
-
     rmtDelete(ObjectAllocator, rmt->propertyAllocator);
 
 #if RMT_USE_VULKAN
@@ -7129,6 +7123,12 @@ static void Remotery_Destructor(Remotery* rmt)
 #if RMT_USE_METAL
     rmtDelete(Metal, rmt->metal);
 #endif
+
+    if (g_RemoteryCreated)
+    {
+        g_Remotery = NULL;
+        g_RemoteryCreated = RMT_FALSE;
+    }
 
     rmtCloseFile(rmt->logfile);
 

--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -10441,7 +10441,7 @@ static rmtError VulkanMarkFrame(VulkanBindImpl* bind)
     return RMT_ERROR_NONE;
 }
 
-RMT_API rmtError _rmt_BindVulkan(void* instance, void* physical_device, void* device, void* queue, VulkanGetInstanceProcAddr get_instance_proc_addr, rmtVulkanBind** out_bind)
+RMT_API rmtError _rmt_BindVulkan(void* instance, void* physical_device, void* device, void* queue, rmtVulkanGetInstanceProcAddr get_instance_proc_addr, rmtVulkanBind** out_bind)
 {
     VulkanBindImpl* bind;
     VkInstance vulkan_instance = (VkInstance)instance;

--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -51,6 +51,7 @@
     @D3D12:         Direct3D 12 event sampling
     @OPENGL:        OpenGL event sampling
     @METAL:         Metal event sampling
+    @VULKAN:        Vulkan event sampling
     @SAMPLEAPI:     Sample API for user callbacks
     @PROPERTYAPI:   Property API for user callbacks
     @PROPERTIES:    Property API
@@ -392,6 +393,14 @@ static void usTimer_Init(usTimer* timer)
 #endif
 }
 
+#if defined(RMT_PLATFORM_WINDOWS)
+    #define usTimer_FromRawTicks(timer, ticks) (rmtU64)(((ticks) - (timer)->counter_start.QuadPart) * (timer)->counter_scale)
+#elif defined(RMT_PLATFORM_MACOS)
+    #define usTimer_FromRawTicks(timer, ticks) (rmtU64)(((ticks) - (timer)->counter_start) * (timer)->counter_scale)
+#elif defined(RMT_PLATFORM_LINUX)
+    #define usTimer_FromRawTicks(timer, ticks) (rmtU64)((ticks) - (timer)->counter_start)
+#endif
+
 static rmtU64 usTimer_Get(usTimer* timer)
 {
 #if defined(RMT_PLATFORM_WINDOWS)
@@ -401,18 +410,19 @@ static rmtU64 usTimer_Get(usTimer* timer)
 
     // Read counter and convert to microseconds
     QueryPerformanceCounter(&performance_count);
-    return (rmtU64)((performance_count.QuadPart - timer->counter_start.QuadPart) * timer->counter_scale);
+    return usTimer_FromRawTicks(timer, performance_count.QuadPart);
 
 #elif defined(RMT_PLATFORM_MACOS)
 
     rmtU64 curr_time = mach_absolute_time();
-    return (rmtU64)((curr_time - timer->counter_start) * timer->counter_scale);
+    return usTimer_FromRawTicks(timer, curr_time);
 
 #elif defined(RMT_PLATFORM_LINUX)
 
     struct timespec tv;
     clock_gettime(CLOCK_REALTIME, &tv);
-    return ((rmtU64)(tv.tv_sec * (rmtU64)1000000) + (rmtU64)(tv.tv_nsec * 0.001)) - timer->counter_start;
+    rmtU64 ticks = (rmtU64)(tv.tv_sec * (rmtU64)1000000) + (rmtU64)(tv.tv_nsec * 0.001);
+    return usTimer_FromRawTicks(timer, ticks);
 
 #endif
 }
@@ -5162,6 +5172,12 @@ static rmtError D3D12ThreadData_Create(D3D12ThreadData** d3d12);
 static void D3D12ThreadData_Destructor(D3D12ThreadData* d3d12);
 #endif
 
+#if RMT_USE_VULKAN
+typedef struct VulkanThreadData VulkanThreadData;
+static rmtError VulkanThreadData_Create(VulkanThreadData** vulkan);
+static void VulkanThreadData_Destructor(VulkanThreadData* vulkan);
+#endif
+
 typedef struct ThreadProfiler
 {
     // Storage for backing up initial register values when modifying a thread's context
@@ -5194,6 +5210,10 @@ typedef struct ThreadProfiler
 #if RMT_USE_D3D12
     D3D12ThreadData* d3d12ThreadData;
 #endif
+
+#if RMT_USE_VULKAN
+    VulkanThreadData* vulkanThreadData;
+#endif
 } ThreadProfiler;
 
 static rmtError ThreadProfiler_Constructor(rmtMessageQueue* mq_to_rmt, ThreadProfiler* thread_profiler, rmtThreadId thread_id)
@@ -5213,6 +5233,10 @@ static rmtError ThreadProfiler_Constructor(rmtMessageQueue* mq_to_rmt, ThreadPro
 
 #if RMT_USE_D3D12
     thread_profiler->d3d12ThreadData = NULL;
+#endif
+
+#if RMT_USE_VULKAN
+    thread_profiler->vulkanThreadData = NULL;
 #endif
 
     // Pre-open the thread handle
@@ -5237,12 +5261,20 @@ static rmtError ThreadProfiler_Constructor(rmtMessageQueue* mq_to_rmt, ThreadPro
     rmtTry(D3D12ThreadData_Create(&thread_profiler->d3d12ThreadData));
 #endif
 
+#if RMT_USE_VULKAN
+    rmtTry(VulkanThreadData_Create(&thread_profiler->vulkanThreadData));
+#endif
+
     return RMT_ERROR_NONE;
 }
 
 static void ThreadProfiler_Destructor(ThreadProfiler* thread_profiler)
 {
     rmtU32 index;
+
+#if RMT_USE_VULKAN
+    rmtDelete(VulkanThreadData, thread_profiler->vulkanThreadData);
+#endif
 
 #if RMT_USE_D3D12
     rmtDelete(D3D12ThreadData, thread_profiler->d3d12ThreadData);
@@ -6222,6 +6254,12 @@ struct Remotery
     struct D3D12BindImpl* d3d12Binds;
 #endif
 
+#if RMT_USE_VULKAN
+    // Linked list of all Vulkan queue samplers
+    rmtMutex vulkanBindsMutex;
+    struct VulkanBindImpl* vulkanBinds;
+#endif
+
     ThreadProfilers* threadProfilers;
 
     // Root of all registered properties, guarded by mutex as property register can come from any thread
@@ -6409,6 +6447,10 @@ static rmtError bin_SampleTree(Buffer* buffer, Msg_SampleTree* msg)
     if (root_sample->type == RMT_SampleType_Metal)
     {
         strncat_s(thread_name, sizeof(thread_name), " (Metal)", 8);
+    }
+    if (root_sample->type == RMT_SampleType_Vulkan)
+    {
+        strncat_s(thread_name, sizeof(thread_name), " (Vulkan)", 9);
     }
 
     // Get digest hash of samples so that viewer can efficiently rebuild its tables
@@ -6961,6 +7003,11 @@ static rmtError Remotery_Constructor(Remotery* rmt)
     rmt->d3d12Binds = NULL;
 #endif
 
+#if RMT_USE_VULKAN
+    mtxInit(&rmt->vulkanBindsMutex);
+    rmt->vulkanBinds = NULL;
+#endif
+
     // Kick-off the timer
     usTimer_Init(&rmt->timer);
 
@@ -7059,6 +7106,13 @@ static void Remotery_Destructor(Remotery* rmt)
 
     rmtDelete(ObjectAllocator, rmt->propertyAllocator);
 
+#if RMT_USE_VULKAN
+    while (rmt->vulkanBinds != NULL)
+    {
+        _rmt_UnbindVulkan((rmtVulkanBind*)rmt->vulkanBinds);
+    }
+    mtxDelete(&rmt->vulkanBindsMutex);
+#endif
 
 #if RMT_USE_D3D12
     while (rmt->d3d12Binds != NULL)
@@ -7446,6 +7500,10 @@ RMT_API void _rmt_EndCPUSample(void)
 static rmtError D3D12MarkFrame(struct D3D12BindImpl* bind);
 #endif
 
+#if RMT_USE_VULKAN
+static rmtError VulkanMarkFrame(struct VulkanBindImpl* bind);
+#endif
+
 RMT_API rmtError _rmt_MarkFrame(void)
 {
     if (g_Remotery == NULL)
@@ -7458,10 +7516,15 @@ RMT_API rmtError _rmt_MarkFrame(void)
         rmtTry(D3D12MarkFrame(g_Remotery->d3d12Binds));
     #endif
 
+    #if RMT_USE_VULKAN
+        // This will kick off mark frames on the complete chain of binds
+        rmtTry(VulkanMarkFrame(g_Remotery->vulkanBinds));
+    #endif
+
     return RMT_ERROR_NONE;
 }
 
-#if RMT_USE_OPENGL || RMT_USE_D3D11 || RMT_USE_D3D12
+#if RMT_USE_OPENGL || RMT_USE_D3D11 || RMT_USE_D3D12 || RMT_USE_VULKAN
 static void Remotery_DeleteSampleTree(Remotery* rmt, enum rmtSampleType sample_type)
 {
     ThreadProfiler* thread_profiler;
@@ -8738,7 +8801,7 @@ static rmtError D3D12MarkFrame(D3D12BindImpl* bind)
         gpu_timestamp_us = (rmtU64)(gpu_timestamp_ticks * gpu_ticks_to_us);
 
         // Convert CPU ticks to microseconds, offset from the global timer start
-        cpu_timestamp_us = (rmtU64)((cpu_timestamp_ticks - g_Remotery->timer.counter_start.QuadPart) * g_Remotery->timer.counter_scale);
+        cpu_timestamp_us = usTimer_FromRawTicks(&g_Remotery->timer, cpu_timestamp_ticks);
 
         // And we now have the offset from GPU microseconds to CPU microseconds
         gpu_to_cpu_timestamp_us = cpu_timestamp_us - gpu_timestamp_us;
@@ -9885,6 +9948,658 @@ RMT_API void _rmt_EndMetalSample(void)
 }
 
 #endif // RMT_USE_METAL
+
+/*
+------------------------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------
+   @VULKAN: Vulkan event sampling
+------------------------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------
+*/
+
+#if RMT_USE_VULKAN
+
+#include <vulkan/vulkan.h>
+
+typedef struct VulkanThreadData
+{
+    rmtU32 lastAllocatedQueryIndex;
+
+    // Sample trees in transit in the message queue for release on shutdown
+    Buffer* flushSamples;
+} VulkanThreadData;
+
+static rmtError VulkanThreadData_Create(VulkanThreadData** vulkan_thread_data)
+{
+    assert(vulkan_thread_data != NULL);
+
+    // Allocate space for the Vulkan data
+    rmtTryMalloc(VulkanThreadData, *vulkan_thread_data);
+
+    // Set defaults
+    (*vulkan_thread_data)->lastAllocatedQueryIndex = 0;
+    (*vulkan_thread_data)->flushSamples = NULL;
+
+    rmtTryNew(Buffer, (*vulkan_thread_data)->flushSamples, 8 * 1024);
+
+    return RMT_ERROR_NONE;
+}
+
+static void VulkanThreadData_Destructor(VulkanThreadData* vulkan_thread_data)
+{
+    assert(vulkan_thread_data != NULL);
+    rmtDelete(Buffer, vulkan_thread_data->flushSamples);
+}
+
+typedef struct VulkanSample
+{
+    // IS-A inheritance relationship
+    Sample base;
+
+    // Cached bind and command buffer used to create the sample so that the user doesn't have to pass it
+    struct VulkanBindImpl* bind;
+    VkCommandBuffer commandBuffer;
+
+    // Begin/End timestamp indices in the query heap
+    rmtU32 queryIndex;
+
+} VulkanSample;
+
+static rmtError VulkanSample_Constructor(VulkanSample* sample)
+{
+    assert(sample != NULL);
+
+    // Chain to sample constructor
+    Sample_Constructor((Sample*)sample);
+    sample->base.type = RMT_SampleType_Vulkan;
+    sample->bind = NULL;
+    sample->commandBuffer = NULL;
+    sample->queryIndex = 0;
+
+    return RMT_ERROR_NONE;
+}
+
+static void VulkanSample_Destructor(VulkanSample* sample)
+{
+    Sample_Destructor((Sample*)sample);
+}
+
+typedef struct VulkanBindImpl
+{
+    rmtVulkanBind base;
+
+    // Ring buffer of GPU timestamp destinations for all queries
+    rmtU32 maxNbQueries;
+    VkQueryPool gpuTimestampRingBuffer;
+
+    // CPU-accessible copy destination for all timestamps
+    rmtU64* cpuTimestampRingBuffer;
+
+    // Pointers to samples that expect the result of timestamps
+    VulkanSample** sampleRingBuffer;
+
+    // Read/write positions of the ring buffer allocator, synchronising access to all the ring buffers at once
+    // TODO(don): Separate by cache line?
+    rmtAtomicU32 ringBufferRead;
+    rmtAtomicU32 ringBufferWrite;
+
+    VkSemaphore gpuQuerySemaphore;
+
+    // Convert gpu ticks to us, retrieved from physical device properties
+    double gpu_ticks_to_us;
+
+    // Function pointers to Vulkan functions
+    PFN_vkQueueSubmit vkQueueSubmit;
+    PFN_vkGetPhysicalDeviceProperties vkGetPhysicalDeviceProperties;
+    PFN_vkCreateQueryPool vkCreateQueryPool;
+    PFN_vkDestroyQueryPool vkDestroyQueryPool;
+    PFN_vkResetQueryPool vkResetQueryPool; // VK_EXT_host_query_reset or VK_VERSION_1_2
+    PFN_vkGetQueryPoolResults vkGetQueryPoolResults;
+    PFN_vkCmdWriteTimestamp vkCmdWriteTimestamp;
+    PFN_vkCreateSemaphore vkCreateSemaphore; // Creating a timeline semaphore, so VK_KHR_timeline_semaphore or VK_VERSION_1_2
+    PFN_vkDestroySemaphore vkDestroySemaphore;
+    PFN_vkSignalSemaphore vkSignalSemaphore; // VK_KHR_timeline_semaphore or VK_VERSION_1_2
+    PFN_vkGetSemaphoreCounterValue vkGetSemaphoreCounterValue; // VK_KHR_timeline_semaphore or VK_VERSION_1_2
+    PFN_vkGetCalibratedTimestampsEXT vkGetCalibratedTimestampsEXT; // VK_EXT_calibrated_timestamps or VK_KHR_calibrated_timestamps
+
+    // Queue to the Vulkan main update thread
+    rmtMessageQueue* mqToVulkanUpdate;
+
+    struct VulkanBindImpl* next;
+
+} VulkanBindImpl;
+
+static rmtError LoadVulkanFunctions(VulkanBindImpl* bind, VkInstance vulkan_instance, VkDevice vulkan_device)
+{
+    PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr;
+    PFN_vkGetDeviceProcAddr vkGetDeviceProcAddr;
+
+#define VK_DEVICE_FN(fn)                                                         \
+    bind->fn = (PFN_ ## fn)vkGetDeviceProcAddr(vulkan_device, #fn);              \
+    if (bind->fn == NULL)                                                        \
+        return RMT_ERROR_RESOURCE_ACCESS_FAIL;
+
+#define VK_DEVICE_FN_FALLBACK(fn, fn_fallback)                                   \
+    bind->fn = (PFN_ ## fn)vkGetDeviceProcAddr(vulkan_device, #fn);              \
+    if (bind->fn == NULL)                                                        \
+    {                                                                            \
+        bind->fn = (PFN_ ## fn)vkGetDeviceProcAddr(vulkan_device, #fn_fallback); \
+        if (bind->fn == NULL)                                                    \
+            return RMT_ERROR_RESOURCE_ACCESS_FAIL;                               \
+    }
+
+    VK_DEVICE_FN(vkQueueSubmit);
+    VK_DEVICE_FN(vkGetPhysicalDeviceProperties);
+    VK_DEVICE_FN(vkCreateQueryPool);
+    VK_DEVICE_FN(vkDestroyQueryPool);
+    VK_DEVICE_FN_FALLBACK(vkResetQueryPool, vkResetQueryPoolEXT);
+    VK_DEVICE_FN(vkGetQueryPoolResults);
+    VK_DEVICE_FN(vkCmdWriteTimestamp);
+    VK_DEVICE_FN(vkCreateSemaphore);
+    VK_DEVICE_FN(vkDestroySemaphore);
+    VK_DEVICE_FN_FALLBACK(vkSignalSemaphore, vkSignalSemaphoreKHR);
+    VK_DEVICE_FN_FALLBACK(vkGetSemaphoreCounterValue, vkGetSemaphoreCounterValueKHR);
+    VK_DEVICE_FN(vkGetCalibratedTimestampsEXT); // TODO(valakor): Support vkGetCalibratedTimestampsKHR
+
+#undef VK_DEVICE_FN
+#undef VK_DEVICE_FN_FALLBACK
+
+    return RMT_ERROR_NONE;
+}
+
+static rmtError CreateQueryPool(VulkanBindImpl* bind, VkDevice vulkan_device, rmtU32 nb_queries)
+{
+    VkQueryPoolCreateInfo create_info;
+    ZeroMemory(&create_info, sizeof(create_info));
+    create_info.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
+    create_info.queryType = VK_QUERY_TYPE_TIMESTAMP;
+    create_info.queryCount = nb_queries;
+
+    if (bind->vkCreateQueryPool(vulkan_device, &create_info, NULL, &bind->gpuTimestampRingBuffer) != VK_SUCCESS)
+    {
+        return rmtMakeError(RMT_ERROR_RESOURCE_CREATE_FAIL, "Failed to create Vulkan Query Pool");
+    }
+
+    bind->vkResetQueryPool(vulkan_device, bind->gpuTimestampRingBuffer, 0, nb_queries);
+
+    return RMT_ERROR_NONE;
+}
+
+static rmtError CreateQuerySemaphore(VulkanBindImpl* bind, VkDevice vulkan_device)
+{
+    VkSemaphoreTypeCreateInfoKHR type_info;
+    ZeroMemory(&type_info, sizeof(type_info));
+    type_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO_KHR;
+    type_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE_KHR;
+    type_info.initialValue = 0;
+
+    VkSemaphoreCreateInfo create_info;
+    ZeroMemory(&create_info, sizeof(create_info));
+    create_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+
+    if (bind->vkCreateSemaphore(vulkan_device, &create_info, NULL, &bind->gpuQuerySemaphore) != VK_SUCCESS)
+    {
+        return rmtMakeError(RMT_ERROR_RESOURCE_CREATE_FAIL, "Failed to create Vulkan Query Semaphore");
+    }
+
+    return RMT_ERROR_NONE;
+}
+
+static rmtError CopyTimestamps(VulkanBindImpl* bind, VkDevice vulkan_device, rmtU32 ring_pos_a, rmtU32 ring_pos_b, double gpu_ticks_to_us, rmtS64 gpu_to_cpu_timestamp_us)
+{
+    rmtU32 query_index;
+    VulkanSample** cpu_sample_buffer = bind->sampleRingBuffer;
+    rmtU64* cpu_timestamps = bind->cpuTimestampRingBuffer;
+
+    rmtU32 query_count = ring_pos_b - ring_pos_a;
+    rmtU64 query_size = query_count * sizeof(rmtU64);
+
+    bind->vkGetQueryPoolResults(vulkan_device, bind->gpuTimestampRingBuffer, ring_pos_a, query_count, query_size, cpu_timestamps + ring_pos_a,
+                              sizeof(rmtU64), VK_QUERY_RESULT_64_BIT);
+
+    // Copy all timestamps to their expectant samples
+    for (query_index = ring_pos_a; query_index < ring_pos_b; query_index += 2)
+    {
+        rmtU64 us_start = (rmtU64)(cpu_timestamps[query_index] * gpu_ticks_to_us + gpu_to_cpu_timestamp_us);
+        rmtU64 us_end = (rmtU64)(cpu_timestamps[query_index + 1] * gpu_ticks_to_us + gpu_to_cpu_timestamp_us);
+
+        VulkanSample* sample = cpu_sample_buffer[query_index >> 1];
+        sample->base.us_start = us_start;
+        Sample_Close(&sample->base, us_end);
+        sample->base.us_end = us_end;
+    }
+
+    // Reset the query pool indices
+    bind->vkResetQueryPool(vulkan_device, bind->gpuTimestampRingBuffer, ring_pos_a, query_count);
+
+    return RMT_ERROR_NONE;
+}
+
+static rmtError UpdateGpuTicksToUs(VulkanBindImpl* bind, VkPhysicalDevice vulkan_physical_device)
+{
+    // TODO(valakor): Is this slow? We could cache timestampPeriod during initialization, but on some devices
+    //  (namely some Apple devices using Vulkan via MoltenVK, potentially others) the value is dynamic and can
+    //  change on every call. For more information see:
+    //  https://github.com/KhronosGroup/MoltenVK/blob/main/Docs/MoltenVK_Runtime_UserGuide.md
+
+    VkPhysicalDeviceProperties device_properties;
+    ZeroMemory(&device_properties, sizeof(device_properties));
+    bind->vkGetPhysicalDeviceProperties(vulkan_physical_device, &device_properties);
+
+    float gpu_ns_per_tick = device_properties.limits.timestampPeriod;
+    bind->gpu_ticks_to_us = gpu_ns_per_tick / 1000.0;
+}
+
+static rmtError GetTimestampCalibration(VulkanBindImpl* bind, VkPhysicalDevice vulkan_physical_device, VkDevice vulkan_device, double* gpu_ticks_to_us, rmtS64* gpu_to_cpu_timestamp_us)
+{
+    // TODO(valakor): Honor RMT_GPU_CPU_SYNC_SECONDS? It's unclear to me how expensive vkGetCalibratedTimestampsEXT is
+    //  on all supported platforms.
+
+    rmtU64 gpu_timestamp_ticks;
+    rmtU64 cpu_timestamp_ticks;
+    rmtU64 gpu_timestamp_us;
+    rmtU64 cpu_timestamp_us;
+    float gpu_tick_period;
+
+    // Always query a device timestamp
+    rmtU32 timestamp_count = 1;
+    rmtU64 max_deviation;
+    rmtU64 timestamps[2];
+    VkCalibratedTimestampInfoEXT timestamp_infos[2];
+    ZeroMemory(&timestamp_infos, sizeof(timestamp_infos));
+    timestamp_infos[0].sType = VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT;
+    timestamp_infos[0].timeDomain = VK_TIME_DOMAIN_DEVICE_EXT;
+
+    // Potentially also query a cpu timestamp if supported
+#if defined(RMT_PLATFORM_WINDOWS)
+    timestamp_count = 2;
+    timestamp_infos[1].sType = VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT;
+    timestamp_infos[1].timeDomain = VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT;
+#elif defined(RMT_PLATFORM_MACOS)
+    // On Apple platforms MoltenVK reports support for VK_TIME_DOMAIN_CLOCK_MONOTONIC_RAW_EXT even though under the hood
+    //  it uses mach_absolute_time(), which is actually CLOCK_BOOT. This doesn't matter though as Remotery also uses
+    //  mach_absolute_time() for time measurements so the results are comparable. For more information see:
+    //  <INSERT LINK HERE>
+    timestamp_count = 2;
+    timestamp_infos[1].sType = VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT;
+    timestamp_infos[1].timeDomain = VK_TIME_DOMAIN_CLOCK_MONOTONIC_RAW_EXT;
+#else
+    // On Linux Remotery uses CLOCK_REALTIME (though it probably shouldn't), but Vulkan only provides time domains for
+    //  CLOCK_MONOTONIC and CLOCK_MONOTONIC_RAW. For now we'll just query the CPU here manually and hope it's close enough.
+    timestamp_count = 1;
+#endif
+
+    // TODO(valakor): Consider taking max_deviation into account. Docs state that users may want to call vkGetCalibratedTimestamps
+    //  multiple times in a row until retrieving a max deviation that is "acceptable". We could just call it a set number of
+    //  times and take the min, or determine a reasonable average during init and ensure we get something close to that here.
+
+    if (bind->vkGetCalibratedTimestampsEXT(vulkan_device, timestamp_count, timestamp_infos, timestamps, &max_deviation) != VK_SUCCESS)
+    {
+        return rmtMakeError(RMT_ERROR_RESOURCE_ACCESS_FAIL, "Failed to get Vulkan calibrated timestamps");
+    }
+
+    // Convert CPU ticks to microseconds, offset from the global timer start
+#if defined(RMT_PLATFORM_WINDOWS) || defined(RMT_PLATFORM_MACOS)
+    cpu_timestamp_ticks = timestamps[1];
+    cpu_timestamp_us = usTimer_FromRawTicks(&g_Remotery->timer, cpu_timestamp_ticks);
+#else
+    cpu_timestamp_us = usTimer_Get(&g_Remotery->timer);
+#endif
+
+    UpdateGpuTicksToUs(bind, vulkan_physical_device);
+    *gpu_ticks_to_us = bind->gpu_ticks_to_us;
+
+    // Convert GPU ticks to microseconds
+    gpu_timestamp_ticks = timestamps[0];
+    gpu_timestamp_us = (rmtU64)(gpu_timestamp_ticks * bind->gpu_ticks_to_us);
+
+    // And we now have the offset from GPU microseconds to CPU microseconds
+    *gpu_to_cpu_timestamp_us = cpu_timestamp_us - gpu_timestamp_us;
+
+    return RMT_ERROR_NONE;
+}
+
+static rmtError VulkanMarkFrame(VulkanBindImpl* bind)
+{
+    if (bind == NULL)
+    {
+        return RMT_ERROR_NONE;
+    }
+
+    VkPhysicalDevice vulkan_physical_device = (VkPhysicalDevice)bind->base.physical_device;
+    VkDevice vulkan_device = (VkDevice)bind->base.device;
+    VkQueue vulkan_queue = (VkQueue)bind->base.queue;
+
+    rmtU32 index_mask = bind->maxNbQueries - 1;
+    rmtU32 current_read_cpu = LoadAcquire(&bind->ringBufferRead);
+    rmtU32 current_write_cpu = LoadAcquire(&bind->ringBufferWrite);
+
+    // Tell the GPU where the CPU write position is
+    VkTimelineSemaphoreSubmitInfoKHR semaphore_submit_info;
+    ZeroMemory(&semaphore_submit_info, sizeof(semaphore_submit_info));
+    semaphore_submit_info.sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO_KHR;
+    semaphore_submit_info.signalSemaphoreValueCount = 1;
+    semaphore_submit_info.pSignalSemaphoreValues = &current_write_cpu;
+
+    VkSubmitInfo submit_info;
+    ZeroMemory(&submit_info, sizeof(submit_info));
+    submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submit_info.pNext = &semaphore_submit_info;
+    submit_info.signalSemaphoreCount = 1;
+    submit_info.pSignalSemaphores = &bind->gpuQuerySemaphore;
+    bind->vkQueueSubmit(vulkan_queue, 1, &submit_info, NULL);
+
+    // Has the GPU processed any writes?
+    rmtU64 current_write_gpu = 0;
+    if (bind->vkGetSemaphoreCounterValue(vulkan_device, bind->gpuQuerySemaphore, &current_write_gpu) != VK_SUCCESS)
+    {
+        return rmtMakeError(RMT_ERROR_RESOURCE_ACCESS_FAIL, "Failed to get Vulkan Semaphore value");
+    }
+
+    if (current_write_gpu > current_read_cpu)
+    {
+        double gpu_ticks_to_us;
+        rmtS64 gpu_to_cpu_timestamp_us;
+
+        // Physical ring buffer positions
+        rmtU32 ring_pos_a = current_read_cpu & index_mask;
+        rmtU32 ring_pos_b = current_write_gpu & index_mask;
+
+        rmtTry(GetTimestampCalibration(bind, vulkan_physical_device, vulkan_device, &gpu_ticks_to_us, &gpu_to_cpu_timestamp_us));
+
+        // Copy resulting timestamps to their samples
+        // Will have to split the copies into two passes if they cross the ring buffer wrap around
+        if (ring_pos_b < ring_pos_a)
+        {
+            rmtTry(CopyTimestamps(bind, vulkan_device, ring_pos_a, bind->maxNbQueries, gpu_ticks_to_us, gpu_to_cpu_timestamp_us));
+            rmtTry(CopyTimestamps(bind, vulkan_device, 0, ring_pos_b, gpu_ticks_to_us, gpu_to_cpu_timestamp_us));
+        }
+        else
+        {
+            rmtTry(CopyTimestamps(bind, vulkan_device, ring_pos_a, ring_pos_b, gpu_ticks_to_us, gpu_to_cpu_timestamp_us));
+        }
+
+        // Release the ring buffer entries just processed
+        StoreRelease(&bind->ringBufferRead, current_write_gpu);
+    }
+
+    // Attempt to empty the queue of complete message trees
+    Message* message;
+    while ((message = rmtMessageQueue_PeekNextMessage(bind->mqToVulkanUpdate)))
+    {
+        Msg_SampleTree* msg_sample_tree;
+        Sample* root_sample;
+
+        // Ensure only Vulkan sample tree messages come through here
+        assert(message->id == MsgID_SampleTree);
+        msg_sample_tree = (Msg_SampleTree*)message->payload;
+        root_sample = msg_sample_tree->rootSample;
+        assert(root_sample->type == RMT_SampleType_Vulkan);
+
+        // If the last-allocated query in this tree has been GPU-processed it's safe to now send the tree to Remotery thread
+        if (current_write_gpu > msg_sample_tree->userData)
+        {
+            QueueSampleTree(g_Remotery->mq_to_rmt_thread, root_sample, msg_sample_tree->allocator, msg_sample_tree->threadName,
+                                0, message->threadProfiler, RMT_FALSE);
+            rmtMessageQueue_ConsumeNextMessage(bind->mqToVulkanUpdate, message);
+        }
+        else
+        {
+            break;
+        }
+    }
+
+    // Chain to the next bind here so that root calling code doesn't need to know the definition of VulkanBindImpl
+    rmtTry(VulkanMarkFrame(bind->next));
+
+    return RMT_ERROR_NONE;
+}
+
+RMT_API rmtError _rmt_BindVulkan(void* instance, void* physical_device, void* device, void* queue, rmtVulkanBind** out_bind)
+{
+    VulkanBindImpl* bind;
+    VkInstance vulkan_instance = (VkInstance)instance;
+    VkPhysicalDevice vulkan_physical_device = (VkPhysicalDevice)physical_device;
+    VkDevice vulkan_device = (VkDevice)device;
+    VkQueue vulkan_queue = (VkQueue)queue;
+
+    if (g_Remotery == NULL)
+    {
+        return RMT_ERROR_REMOTERY_NOT_CREATED;
+    }
+
+    assert(vulkan_instance != NULL);
+    assert(physical_device != NULL);
+    assert(device != NULL);
+    assert(queue != NULL);
+    assert(out_bind != NULL);
+
+    // Allocate the bind container
+    rmtTryMalloc(VulkanBindImpl, bind);
+
+    // Set default state
+    bind->base.physical_device = physical_device;
+    bind->base.device = device;
+    bind->base.queue = queue;
+    bind->maxNbQueries = 32 * 1024;
+    bind->gpuTimestampRingBuffer = NULL;
+    bind->cpuTimestampRingBuffer = NULL;
+    bind->sampleRingBuffer = NULL;
+    bind->ringBufferRead = 0;
+    bind->ringBufferWrite = 0;
+    bind->gpuQuerySemaphore = NULL;
+    bind->gpu_ticks_to_us = 1.0;
+    bind->vkQueueSubmit = NULL;
+    bind->vkGetPhysicalDeviceProperties = NULL;
+    bind->vkCreateQueryPool = NULL;
+    bind->vkDestroyQueryPool = NULL;
+    bind->vkResetQueryPool = NULL;
+    bind->vkGetQueryPoolResults = NULL;
+    bind->vkCmdWriteTimestamp = NULL;
+    bind->vkCreateSemaphore = NULL;
+    bind->vkDestroySemaphore = NULL;
+    bind->vkSignalSemaphore = NULL;
+    bind->vkGetSemaphoreCounterValue = NULL;
+    bind->vkGetCalibratedTimestampsEXT = NULL;
+    bind->mqToVulkanUpdate = NULL;
+    bind->next = NULL;
+
+    rmtTry(LoadVulkanFunctions(bind, vulkan_instance, vulkan_device));
+
+    // Create the independent ring buffer storage items
+    // TODO(don): Leave space beetween start and end to stop invalidating cache lines?
+    // NOTE(don): ABA impossible due to non-wrapping ring buffer indices
+    rmtTry(CreateQueryPool(bind, vulkan_device, bind->maxNbQueries));
+    rmtTryMallocArray(VulkanSample*, bind->sampleRingBuffer, bind->maxNbQueries / 2);
+    rmtTryMallocArray(rmtU64, bind->cpuTimestampRingBuffer, bind->maxNbQueries);
+    rmtTry(CreateQuerySemaphore(bind, vulkan_device));
+
+    rmtTryNew(rmtMessageQueue, bind->mqToVulkanUpdate, g_Settings.messageQueueSizeInBytes);
+
+    // Add to the global linked list of binds
+    {
+        mtxLock(&g_Remotery->vulkanBindsMutex);
+        bind->next = g_Remotery->vulkanBinds;
+        g_Remotery->vulkanBinds = bind;
+        mtxUnlock(&g_Remotery->vulkanBindsMutex);
+    }
+
+    *out_bind = &bind->base;
+
+    return RMT_ERROR_NONE;
+}
+
+RMT_API void _rmt_UnbindVulkan(rmtVulkanBind* bind)
+{
+    VulkanBindImpl* vulkan_bind = (VulkanBindImpl*)bind;
+    VkDevice vulkan_device = (VkDevice)vulkan_bind->base.device;
+
+    assert(bind != NULL);
+
+    // Remove from the linked list
+    {
+        mtxLock(&g_Remotery->vulkanBindsMutex);
+        VulkanBindImpl* cur = g_Remotery->vulkanBinds;
+        VulkanBindImpl* prev = NULL;
+        for ( ; cur != NULL; cur = cur->next)
+        {
+            if (cur == vulkan_bind)
+            {
+                if (prev != NULL)
+                {
+                    prev->next = cur->next;
+                }
+                else
+                {
+                    g_Remotery->vulkanBinds = cur->next;
+                }
+
+                break;
+            }
+        }
+        mtxUnlock(&g_Remotery->vulkanBindsMutex);
+    }
+
+    // TODO: Clean up resources
+
+    if (vulkan_bind->gpuQuerySemaphore != NULL)
+    {
+        vulkan_bind->vkDestroySemaphore(vulkan_device, vulkan_bind->gpuQuerySemaphore, NULL);
+    }
+
+    rmtFree(vulkan_bind->sampleRingBuffer);
+    rmtFree(vulkan_bind->cpuTimestampRingBuffer);
+
+    if (vulkan_bind->gpuTimestampRingBuffer != NULL)
+    {
+        vulkan_bind->vkDestroyQueryPool(vulkan_device, vulkan_bind->gpuTimestampRingBuffer, NULL);
+    }
+}
+
+static rmtError AllocateVulkanSampleTree(SampleTree** vulkan_tree)
+{
+    rmtTryNew(SampleTree, *vulkan_tree, sizeof(VulkanSample), (ObjConstructor)VulkanSample_Constructor,
+            (ObjDestructor)VulkanSample_Destructor);
+    return RMT_ERROR_NONE;
+}
+
+static rmtError AllocQueryPair(VulkanBindImpl* vulkan_bind, rmtAtomicU32* out_allocation_index)
+{
+    // Check for overflow against a tail which is only ever written by one thread
+    rmtU32 read = LoadAcquire(&vulkan_bind->ringBufferRead);
+    rmtU32 write = LoadAcquire(&vulkan_bind->ringBufferWrite);
+    rmtU32 nb_queries = (write - read);
+    rmtU32 queries_left = vulkan_bind->maxNbQueries - nb_queries;
+    if (queries_left < 2)
+    {
+        return rmtMakeError(RMT_ERROR_RESOURCE_CREATE_FAIL, "Vulkan query ring buffer overflow");
+    }
+
+    *out_allocation_index = AtomicAddU32(&vulkan_bind->ringBufferWrite, 2);
+    return RMT_ERROR_NONE;
+}
+
+RMT_API void _rmt_BeginVulkanSample(rmtVulkanBind* bind, void* command_buffer, rmtPStr name, rmtU32* hash_cache)
+{
+    ThreadProfiler* thread_profiler;
+
+    if (g_Remotery == NULL || bind == NULL)
+        return;
+
+    assert(command_buffer != NULL);
+
+    if (ThreadProfilers_GetCurrentThreadProfiler(g_Remotery->threadProfilers, &thread_profiler) == RMT_ERROR_NONE)
+    {
+        Sample* sample;
+        rmtU32 name_hash;
+        SampleTree** vulkan_tree;
+
+        name_hash = ThreadProfiler_GetNameHash(thread_profiler, g_Remotery->mq_to_rmt_thread, name, hash_cache);
+
+        // Create the Vulkan tree on-demand as the tree needs an up-front-created root.
+        // This is not possible to create on initialisation as a Vulkan binding is not yet available.
+        vulkan_tree = &thread_profiler->sampleTrees[RMT_SampleType_Vulkan];
+        if (*vulkan_tree == NULL)
+        {
+            AllocateVulkanSampleTree(vulkan_tree);
+        }
+
+        // Push the sample and activate the timestamp
+        if (ThreadProfiler_Push(*vulkan_tree, name_hash, 0, &sample) == RMT_ERROR_NONE)
+        {
+            rmtError error;
+
+            VulkanBindImpl* vulkan_bind = (VulkanBindImpl*)bind;
+            VkCommandBuffer vulkan_command_buffer = (VkCommandBuffer)command_buffer;
+
+            VulkanSample* vulkan_sample = (VulkanSample*)sample;
+            vulkan_sample->bind = vulkan_bind;
+            vulkan_sample->commandBuffer = vulkan_command_buffer;
+            vulkan_sample->base.usGpuIssueOnCpu = usTimer_Get(&g_Remotery->timer);
+
+            error = AllocQueryPair(vulkan_bind, &vulkan_sample->queryIndex);
+            if (error == RMT_ERROR_NONE)
+            {
+                rmtU32 physical_query_index = vulkan_sample->queryIndex & (vulkan_bind->maxNbQueries - 1);
+                vulkan_bind->vkCmdWriteTimestamp(vulkan_command_buffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, vulkan_bind->gpuTimestampRingBuffer, physical_query_index);
+
+                // Track which Vulkan sample expects the timestamp results
+                vulkan_bind->sampleRingBuffer[physical_query_index / 2] = vulkan_sample;
+
+                // Keep track of the last allocated query so we can check when the GPU has finished with them all
+                thread_profiler->vulkanThreadData->lastAllocatedQueryIndex = vulkan_sample->queryIndex;
+            }
+            else
+            {
+                // SET QUERY INDEX TO INVALID so that pop doesn't release it
+            }
+        }
+    }
+}
+
+RMT_API void _rmt_EndVulkanSample()
+{
+    ThreadProfiler* thread_profiler;
+
+    if (g_Remotery == NULL)
+        return;
+
+    if (ThreadProfilers_GetCurrentThreadProfiler(g_Remotery->threadProfilers, &thread_profiler) == RMT_ERROR_NONE)
+    {
+        VulkanThreadData* vulkan_thread_data = thread_profiler->vulkanThreadData;
+        VulkanSample* vulkan_sample;
+
+        // Sample tree isn't there if Vulkan hasn't been initialised
+        SampleTree* vulkan_tree = thread_profiler->sampleTrees[RMT_SampleType_Vulkan];
+        if (vulkan_tree == NULL)
+        {
+            return;
+        }
+
+        // Close the timestamp
+        vulkan_sample = (VulkanSample*)vulkan_tree->currentParent;
+        if (vulkan_sample->base.recurse_depth > 0)
+        {
+            vulkan_sample->base.recurse_depth--;
+        }
+        else
+        {
+            // Issue the timestamp query for the end of the sample
+            VulkanBindImpl* vulkan_bind = vulkan_sample->bind;
+            VkCommandBuffer vulkan_command_buffer = vulkan_sample->commandBuffer;
+            rmtU32 query_index = vulkan_sample->queryIndex & (vulkan_bind->maxNbQueries - 1);
+            vulkan_bind->vkCmdWriteTimestamp(vulkan_command_buffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                                           vulkan_bind->gpuTimestampRingBuffer, query_index + 1);
+
+            if (ThreadProfiler_Pop(thread_profiler, vulkan_bind->mqToVulkanUpdate, (Sample*)vulkan_sample,
+                                   vulkan_thread_data->lastAllocatedQueryIndex))
+            {
+            }
+        }
+    }
+}
+
+#endif // RMT_USE_VULKAN
 
 /*
 ------------------------------------------------------------------------------------------------------------------------

--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -10441,14 +10441,14 @@ static rmtError VulkanMarkFrame(VulkanBindImpl* bind)
     return RMT_ERROR_NONE;
 }
 
-RMT_API rmtError _rmt_BindVulkan(void* instance, void* physical_device, void* device, void* queue, VulkanGetInstanceProcAddr get_proc_addr, rmtVulkanBind** out_bind)
+RMT_API rmtError _rmt_BindVulkan(void* instance, void* physical_device, void* device, void* queue, VulkanGetInstanceProcAddr get_instance_proc_addr, rmtVulkanBind** out_bind)
 {
     VulkanBindImpl* bind;
     VkInstance vulkan_instance = (VkInstance)instance;
     VkPhysicalDevice vulkan_physical_device = (VkPhysicalDevice)physical_device;
     VkDevice vulkan_device = (VkDevice)device;
     VkQueue vulkan_queue = (VkQueue)queue;
-    PFN_vkGetInstanceProcAddr pfn_vkGetInstanceProcAddr = (PFN_vkGetInstanceProcAddr)get_proc_addr;
+    PFN_vkGetInstanceProcAddr pfn_vkGetInstanceProcAddr = (PFN_vkGetInstanceProcAddr)get_instance_proc_addr;
 
     if (g_Remotery == NULL)
     {
@@ -10460,7 +10460,7 @@ RMT_API rmtError _rmt_BindVulkan(void* instance, void* physical_device, void* de
     assert(device != NULL);
     assert(queue != NULL);
     assert(out_bind != NULL);
-    assert(get_proc_addr != NULL);
+    assert(get_instance_proc_addr != NULL);
 
     // Allocate the bind container
     rmtTryMalloc(VulkanBindImpl, bind);

--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -10463,6 +10463,7 @@ RMT_API rmtError _rmt_BindVulkan(void* instance, void* physical_device, void* de
     assert(get_instance_proc_addr != NULL);
 
     // Allocate the bind container
+    // TODO(valakor): If anything after this fails we'll leak this bind instance
     rmtTryMalloc(VulkanBindImpl, bind);
 
     // Set default state
@@ -10554,7 +10555,9 @@ RMT_API void _rmt_UnbindVulkan(rmtVulkanBind* bind)
         mtxUnlock(&g_Remotery->vulkanBindsMutex);
     }
 
-    // TODO: Clean up resources
+    // Clean up bind resources
+
+    rmtDelete(rmtMessageQueue, vulkan_bind->mqToVulkanUpdate);
 
     if (vulkan_bind->gpuQuerySemaphore != NULL)
     {

--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -10153,6 +10153,9 @@ static rmtError CopyTimestamps(VulkanBindImpl* bind, VkDevice vulkan_device, rmt
     rmtU32 query_count = ring_pos_b - ring_pos_a;
     rmtU64 query_size = query_count * sizeof(rmtU64);
 
+    if (query_count == 0)
+        return RMT_ERROR_NONE;
+
     bind->vkGetQueryPoolResults(vulkan_device, bind->gpuTimestampRingBuffer, ring_pos_a, query_count, query_size, cpu_timestamps + ring_pos_a,
                               sizeof(rmtU64), VK_QUERY_RESULT_64_BIT);
 

--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -10410,26 +10410,26 @@ RMT_API rmtError _rmt_BindVulkan(void* instance, void* physical_device, void* de
         return RMT_ERROR_REMOTERY_NOT_CREATED;
 
     if (instance == NULL)
-        return RMT_ERROR_INVALID_INPUT;
+        return rmtMakeError(RMT_ERROR_INVALID_INPUT, "Missing instance");
 
     if (physical_device == NULL)
-        return RMT_ERROR_INVALID_INPUT;
+        return rmtMakeError(RMT_ERROR_INVALID_INPUT, "Missing physical_device");
 
     if (device == NULL)
-        return RMT_ERROR_INVALID_INPUT;
+        return rmtMakeError(RMT_ERROR_INVALID_INPUT, "Missing device");
 
     if (queue == NULL)
-        return RMT_ERROR_INVALID_INPUT;
+        return rmtMakeError(RMT_ERROR_INVALID_INPUT, "Missing queue");
 
     if (funcs == NULL)
-        return RMT_ERROR_INVALID_INPUT;
+        return rmtMakeError(RMT_ERROR_INVALID_INPUT, "Missing funcs");
 
     if (out_bind == NULL)
-        return RMT_ERROR_INVALID_INPUT;
+        return rmtMakeError(RMT_ERROR_INVALID_INPUT, "Missing out_bind");
 
  #define CHECK_VK_FUNC(fn)                                               \
     if (funcs->fn == NULL)                                               \
-        return RMT_ERROR_INVALID_INPUT;
+        return rmtMakeError(RMT_ERROR_INVALID_INPUT, "Missing " #fn)
 
     CHECK_VK_FUNC(vkGetPhysicalDeviceProperties);
     CHECK_VK_FUNC(vkQueueSubmit);

--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -10285,7 +10285,9 @@ static rmtError GetTimestampCalibration(VulkanBindImpl* bind, VkPhysicalDevice v
     timestamp_count = 2;
     timestamp_infos[1].sType = VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT;
     timestamp_infos[1].timeDomain = VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT;
-#elif defined(RMT_PLATFORM_MACOS)
+#elif 0 // defined(RMT_PLATFORM_MACOS)
+	// TODO(valakor) The comment below would be correct if not for a bug in MoltenVK that returns the wrong timestamp
+	//  value for VK_TIME_DOMAIN_CLOCK_MONOTONIC_RAW_EXT. For now we'll just sample the CPU timestamp manually.
     // On Apple platforms MoltenVK reports support for VK_TIME_DOMAIN_CLOCK_MONOTONIC_RAW_EXT even though under the hood
     //  it uses mach_absolute_time(), which is actually CLOCK_UPTIME_RAW. This doesn't matter though as Remotery also uses
     //  mach_absolute_time() for time measurements so the results are comparable. For more information see:
@@ -10309,7 +10311,7 @@ static rmtError GetTimestampCalibration(VulkanBindImpl* bind, VkPhysicalDevice v
     }
 
     // Convert CPU ticks to microseconds, offset from the global timer start
-#if defined(RMT_PLATFORM_WINDOWS) || defined(RMT_PLATFORM_MACOS)
+#if defined(RMT_PLATFORM_WINDOWS) // || defined(RMT_PLATFORM_MACOS)
     cpu_timestamp_ticks = timestamps[1];
     cpu_timestamp_us = usTimer_FromRawTicks(&g_Remotery->timer, cpu_timestamp_ticks);
 #else

--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -10464,6 +10464,8 @@ RMT_API rmtError _rmt_BindVulkan(void* instance, void* physical_device, void* de
     bind->base.device = device;
     bind->base.queue = queue;
 #ifdef RMT_PLATFORM_MACOS
+	// NOTE(valakor): Vulkan on MacOS via MoltenVK only supports timestamp query pools of up to 4k 64-bit queries. See
+	//  https://github.com/KhronosGroup/MoltenVK/blob/main/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.mm
     bind->maxNbQueries = 4 * 1024;
 #else
 	bind->maxNbQueries = 32 * 1024;

--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -10463,7 +10463,11 @@ RMT_API rmtError _rmt_BindVulkan(void* instance, void* physical_device, void* de
     bind->base.physical_device = physical_device;
     bind->base.device = device;
     bind->base.queue = queue;
-    bind->maxNbQueries = 32 * 1024;
+#ifdef RMT_PLATFORM_MACOS
+    bind->maxNbQueries = 4 * 1024;
+#else
+	bind->maxNbQueries = 32 * 1024;
+#endif
     bind->gpuTimestampRingBuffer = NULL;
     bind->cpuTimestampRingBuffer = NULL;
     bind->sampleRingBuffer = NULL;

--- a/lib/Remotery.h
+++ b/lib/Remotery.h
@@ -30,6 +30,9 @@ Compiling
   library linkage. For example to compile the same run: cc lib/Remotery.c sample/sample.c
   -I lib -pthread -lm
 
+* Vulkan - Ensure your include directories are set such that the Vulkan headers can be
+  included with the statement: #include <vulkan/vulkan.h>.
+
 You can define some extra macros to modify what features are compiled into Remotery. These are
 documented just below this comment.
 

--- a/lib/Remotery.h
+++ b/lib/Remotery.h
@@ -85,8 +85,7 @@ documented just below this comment.
 
 // Allow Vulkan profiling
 #ifndef RMT_USE_VULKAN
-// TODO: Set back to 0 when checking in!
-#define RMT_USE_VULKAN 1
+#define RMT_USE_VULKAN 0
 #endif
 
 // Initially use POSIX thread names to name threads instead of Thread0, 1, ...

--- a/lib/Remotery.h
+++ b/lib/Remotery.h
@@ -349,8 +349,8 @@ typedef enum rmtError
 extern "C" {
 #endif
 
-// Gets the last error message issued on the calling thread
-RMT_API rmtPStr rmt_GetLastErrorMessage();
+    // Gets the last error message issued on the calling thread
+    RMT_API rmtPStr rmt_GetLastErrorMessage();
 
 #ifdef __cplusplus
 }
@@ -638,8 +638,8 @@ typedef struct rmtVulkanBind
 } rmtVulkanBind;
 
 // Create a Vulkan binding for the given device/queue pair
-#define rmt_BindVulkan(instance, physical_device, device, queue, out_bind)  \
-    RMT_OPTIONAL_RET(RMT_USE_VULKAN, _rmt_BindVulkan(instance, physical_device, device, queue, out_bind), NULL)
+#define rmt_BindVulkan(instance, physical_device, device, queue, get_proc_addr, out_bind) \
+    RMT_OPTIONAL_RET(RMT_USE_VULKAN, _rmt_BindVulkan(instance, physical_device, device, queue, get_proc_addr, out_bind), NULL)
 
 #define rmt_UnbindVulkan(bind)                                              \
     RMT_OPTIONAL(RMT_USE_VULKAN, _rmt_UnbindVulkan(bind))
@@ -1136,7 +1136,8 @@ RMT_API void _rmt_EndMetalSample(void);
 #endif
 
 #if RMT_USE_VULKAN
-RMT_API rmtError _rmt_BindVulkan(void* instance, void* physical_device, void* device, void* queue, rmtVulkanBind** out_bind);
+typedef void*(*VulkanGetInstanceProcAddr)(void*, const char*);
+RMT_API rmtError _rmt_BindVulkan(void* instance, void* physical_device, void* device, void* queue, VulkanGetInstanceProcAddr get_proc_addr, rmtVulkanBind** out_bind);
 RMT_API void _rmt_UnbindVulkan(rmtVulkanBind* bind);
 RMT_API void _rmt_BeginVulkanSample(rmtVulkanBind* bind, void* command_buffer, rmtPStr name, rmtU32* hash_cache);
 RMT_API void _rmt_EndVulkanSample();

--- a/lib/Remotery.h
+++ b/lib/Remotery.h
@@ -1067,7 +1067,7 @@ struct rmt_EndVulkanSampleOnScopeExit
         RMT_OPTIONAL(RMT_USE_D3D11, rmt_EndD3D11SampleOnScopeExit rmt_ScopedD3D11Sample##name);
 #define rmt_ScopedD3D12Sample(bind, command_list, name)                                                 \
         RMT_OPTIONAL(RMT_USE_D3D12, rmt_BeginD3D12Sample(bind, command_list, name));                    \
-        RMT_OPTIONAL(RMT_USE_D3D12, rmt_EndD3D12SampleOnScopeExit rmt_ScopedD3D12Sample##name());
+        RMT_OPTIONAL(RMT_USE_D3D12, rmt_EndD3D12SampleOnScopeExit rmt_ScopedD3D12Sample##name);
 #define rmt_ScopedOpenGLSample(name)                                                                    \
         RMT_OPTIONAL(RMT_USE_OPENGL, rmt_BeginOpenGLSample(name));                                      \
         RMT_OPTIONAL(RMT_USE_OPENGL, rmt_EndOpenGLSampleOnScopeExit rmt_ScopedOpenGLSample##name);
@@ -1076,7 +1076,7 @@ struct rmt_EndVulkanSampleOnScopeExit
         RMT_OPTIONAL(RMT_USE_METAL, rmt_EndMetalSampleOnScopeExit rmt_ScopedMetalSample##name);
 #define rmt_ScopedVulkanSample(bind, command_buffer, name)                                              \
         RMT_OPTIONAL(RMT_USE_VULKAN, rmt_BeginVulkanSample(bind, command_buffer, name));                \
-        RMT_OPTIONAL(RMT_USE_VULKAN, rmt_EndVulkanSampleOnScopeExit rmt_ScopedVulkanSample##name());
+        RMT_OPTIONAL(RMT_USE_VULKAN, rmt_EndVulkanSampleOnScopeExit rmt_ScopedVulkanSample##name);
 
 #endif
 

--- a/lib/Remotery.h
+++ b/lib/Remotery.h
@@ -345,8 +345,18 @@ typedef enum rmtError
 } rmtError;
 // clang-format on
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Gets the last error message issued on the calling thread
 RMT_API rmtPStr rmt_GetLastErrorMessage();
+
+#ifdef __cplusplus
+}
+#endif
+
+
 
 
 /*--------------------------------------------------------------------------------------------------------------------------------

--- a/lib/Remotery.h
+++ b/lib/Remotery.h
@@ -1135,8 +1135,8 @@ RMT_API void _rmt_EndMetalSample(void);
 #endif
 
 #if RMT_USE_VULKAN
-typedef void*(*VulkanGetInstanceProcAddr)(void*, const char*);
-RMT_API rmtError _rmt_BindVulkan(void* instance, void* physical_device, void* device, void* queue, VulkanGetInstanceProcAddr get_instance_proc_addr, rmtVulkanBind** out_bind);
+typedef void*(*rmtVulkanGetInstanceProcAddr)(void*, const char*);
+RMT_API rmtError _rmt_BindVulkan(void* instance, void* physical_device, void* device, void* queue, rmtVulkanGetInstanceProcAddr get_instance_proc_addr, rmtVulkanBind** out_bind);
 RMT_API void _rmt_UnbindVulkan(rmtVulkanBind* bind);
 RMT_API void _rmt_BeginVulkanSample(rmtVulkanBind* bind, void* command_buffer, rmtPStr name, rmtU32* hash_cache);
 RMT_API void _rmt_EndVulkanSample();

--- a/lib/Remotery.h
+++ b/lib/Remotery.h
@@ -665,7 +665,7 @@ typedef struct rmtVulkanBind
 
 // Create a Vulkan binding for the given device/queue pair
 #define rmt_BindVulkan(instance, physical_device, device, queue, funcs, out_bind)         \
-    RMT_OPTIONAL_RET(RMT_USE_VULKAN, _rmt_BindVulkan(instance, physical_device, device, queue, funcs, out_bind), NULL)
+    RMT_OPTIONAL_RET(RMT_USE_VULKAN, _rmt_BindVulkan(instance, physical_device, device, queue, funcs, out_bind), RMT_ERROR_NONE)
 
 #define rmt_UnbindVulkan(bind)                                              \
     RMT_OPTIONAL(RMT_USE_VULKAN, _rmt_UnbindVulkan(bind))

--- a/lib/Remotery.h
+++ b/lib/Remotery.h
@@ -31,7 +31,10 @@ Compiling
   -I lib -pthread -lm
 
 * Vulkan - Ensure your include directories are set such that the Vulkan headers can be
-  included with the statement: #include <vulkan/vulkan.h>.
+  included with the statement: #include <vulkan/vulkan.h>. Currently the Vulkan implementation
+  requires either Vulkan 1.2+ with the "hostQueryReset" and "timelineSemaphore" features enabled,
+  or < 1.1 with the "VK_EXT_host_query_reset" and "VK_KHR_timeline_semaphore" extensions. The
+  extension "VK_EXT_calibrated_timestamps" is also always required.
 
 You can define some extra macros to modify what features are compiled into Remotery. These are
 documented just below this comment.

--- a/lib/Remotery.h
+++ b/lib/Remotery.h
@@ -637,8 +637,8 @@ typedef struct rmtVulkanBind
 } rmtVulkanBind;
 
 // Create a Vulkan binding for the given device/queue pair
-#define rmt_BindVulkan(instance, physical_device, device, queue, get_proc_addr, out_bind) \
-    RMT_OPTIONAL_RET(RMT_USE_VULKAN, _rmt_BindVulkan(instance, physical_device, device, queue, get_proc_addr, out_bind), NULL)
+#define rmt_BindVulkan(instance, physical_device, device, queue, get_instance_proc_addr, out_bind) \
+    RMT_OPTIONAL_RET(RMT_USE_VULKAN, _rmt_BindVulkan(instance, physical_device, device, queue, get_instance_proc_addr, out_bind), NULL)
 
 #define rmt_UnbindVulkan(bind)                                              \
     RMT_OPTIONAL(RMT_USE_VULKAN, _rmt_UnbindVulkan(bind))
@@ -1136,7 +1136,7 @@ RMT_API void _rmt_EndMetalSample(void);
 
 #if RMT_USE_VULKAN
 typedef void*(*VulkanGetInstanceProcAddr)(void*, const char*);
-RMT_API rmtError _rmt_BindVulkan(void* instance, void* physical_device, void* device, void* queue, VulkanGetInstanceProcAddr get_proc_addr, rmtVulkanBind** out_bind);
+RMT_API rmtError _rmt_BindVulkan(void* instance, void* physical_device, void* device, void* queue, VulkanGetInstanceProcAddr get_instance_proc_addr, rmtVulkanBind** out_bind);
 RMT_API void _rmt_UnbindVulkan(rmtVulkanBind* bind);
 RMT_API void _rmt_BeginVulkanSample(rmtVulkanBind* bind, void* command_buffer, rmtPStr name, rmtU32* hash_cache);
 RMT_API void _rmt_EndVulkanSample();

--- a/lib/Remotery.h
+++ b/lib/Remotery.h
@@ -626,22 +626,46 @@ typedef struct rmtD3D12Bind
     RMT_OPTIONAL(RMT_USE_METAL, _rmt_EndMetalSample())
 
 
+typedef struct rmtVulkanFunctions
+{
+    // Function pointers to Vulkan functions
+    // Untyped so that the Vulkan headers are not required in this file
+
+    // Instance functions
+    void* vkGetPhysicalDeviceProperties;
+
+    // Device functions
+    void* vkQueueSubmit;
+    void* vkQueueWaitIdle;
+    void* vkCreateQueryPool;
+    void* vkDestroyQueryPool;
+    void* vkResetQueryPool; // vkResetQueryPool (Vulkan 1.2+ with hostQueryReset) or vkResetQueryPoolEXT (VK_EXT_host_query_reset)
+    void* vkGetQueryPoolResults;
+    void* vkCmdWriteTimestamp;
+    void* vkCreateSemaphore;
+    void* vkDestroySemaphore;
+    void* vkSignalSemaphore; // vkSignalSemaphore (Vulkan 1.2+ with timelineSemaphore) or vkSignalSemaphoreKHR (VK_KHR_timeline_semaphore)
+    void* vkGetSemaphoreCounterValue; // vkGetSemaphoreCounterValue (Vulkan 1.2+ with timelineSemaphore) or vkGetSemaphoreCounterValueKHR (VK_KHR_timeline_semaphore)
+    void* vkGetCalibratedTimestampsEXT; // vkGetCalibratedTimestampsKHR (VK_KHR_calibrated_timestamps) or vkGetCalibratedTimestampsEXT (VK_EXT_calibrated_timestamps)
+
+} rmtVulkanFunctions;
+
 typedef struct rmtVulkanBind
 {
-    // The physical vulkan device
+    // The physical Vulkan device, of type VkPhysicalDevice
     void* physical_device;
 
-    // The main device shared by all threads
+    // The logical Vulkan device, of type VkDevice
     void* device;
 
-    // The queue command buffers are executed on for profiling
+    // The queue command buffers are executed on for profiling, of type VkQueue
     void* queue;
 
 } rmtVulkanBind;
 
 // Create a Vulkan binding for the given device/queue pair
-#define rmt_BindVulkan(instance, physical_device, device, queue, get_instance_proc_addr, out_bind) \
-    RMT_OPTIONAL_RET(RMT_USE_VULKAN, _rmt_BindVulkan(instance, physical_device, device, queue, get_instance_proc_addr, out_bind), NULL)
+#define rmt_BindVulkan(instance, physical_device, device, queue, funcs, out_bind)         \
+    RMT_OPTIONAL_RET(RMT_USE_VULKAN, _rmt_BindVulkan(instance, physical_device, device, queue, funcs, out_bind), NULL)
 
 #define rmt_UnbindVulkan(bind)                                              \
     RMT_OPTIONAL(RMT_USE_VULKAN, _rmt_UnbindVulkan(bind))
@@ -1138,8 +1162,7 @@ RMT_API void _rmt_EndMetalSample(void);
 #endif
 
 #if RMT_USE_VULKAN
-typedef void*(*rmtVulkanGetInstanceProcAddr)(void*, const char*);
-RMT_API rmtError _rmt_BindVulkan(void* instance, void* physical_device, void* device, void* queue, rmtVulkanGetInstanceProcAddr get_instance_proc_addr, rmtVulkanBind** out_bind);
+RMT_API rmtError _rmt_BindVulkan(void* instance, void* physical_device, void* device, void* queue, const rmtVulkanFunctions* funcs, rmtVulkanBind** out_bind);
 RMT_API void _rmt_UnbindVulkan(rmtVulkanBind* bind);
 RMT_API void _rmt_BeginVulkanSample(rmtVulkanBind* bind, void* command_buffer, rmtPStr name, rmtU32* hash_cache);
 RMT_API void _rmt_EndVulkanSample();

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,12 @@ Compiling
   ([devel/remotery](https://www.freshports.org/devel/remotery/)) and modify the port's
   Makefile if needed. There is also a package available via `pkg install remotery`.
 
+* Vulkan - Ensure your include directories are set such that the Vulkan headers can be
+  included with the statement: `#include <vulkan/vulkan.h>`. Currently the Vulkan implementation
+  requires either Vulkan 1.2+ with the `hostQueryReset` and `timelineSemaphore` features enabled,
+  or < 1.1 with the `VK_EXT_host_query_reset` and `VK_KHR_timeline_semaphore` extensions. The
+  extension `VK_EXT_calibrated_timestamps` is also always required.
+
 You can define some extra macros to modify what features are compiled into Remotery:
 
     Macro               Default     Description

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ Supported Profiling Platforms:
 
 Supported GPU Profiling APIS:
 
-* D3D 11/12, OpenGL, CUDA, Metal.
+* D3D 11/12, OpenGL, CUDA, Metal, Vulkan.
 
 Compiling
 ---------
@@ -58,6 +58,7 @@ You can define some extra macros to modify what features are compiled into Remot
     RMT_USE_D3D12       0           Allow D3D12 GPU profiling
     RMT_USE_OPENGL      0           Allow OpenGL GPU profiling (dynamically links OpenGL libraries on available platforms)
     RMT_USE_METAL       0           Allow Metal profiling of command buffers
+    RMT_USE_VULKAN      0           Allow Vulkan GPU profiling
 
 
 Basic Use

--- a/readme.md
+++ b/readme.md
@@ -227,8 +227,8 @@ must be submitted to the same queue as the samples are issued to. Multiple queue
 Vulkan bind objects.
 
     rmtVulkanFunctions vulkan_funcs;
-    vulkan_funcs.vkGetPhysicalDeviceProperties = my_vulkan_instance_table->vkGetPhysicalDeviceProperties;
-    vulkan_funcs.vkQueueSubmit = my_vulkan_device_table->vkQueueSubmit;
+    vulkan_funcs.vkGetPhysicalDeviceProperties = (void*)my_vulkan_instance_table->vkGetPhysicalDeviceProperties;
+    vulkan_funcs.vkQueueSubmit = (void*)my_vulkan_device_table->vkQueueSubmit;
     // ... All other function pointers
 
     // Parameters are VkInstance, VkPhysicalDevice, VkDevice, VkQueue, rmtVulkanFunctions*, rmtVulkanBind**

--- a/vis/Code/Remotery.js
+++ b/vis/Code/Remotery.js
@@ -478,39 +478,21 @@ Remotery = (function()
 
     function UInt64ToFloat32(view, offset)
     {
-        // Unpack as two 32-bit integers so we have a vague attempt at reconstructing the value
-        const a = view.getUint32(offset + 0, true);
-        const b = view.getUint32(offset + 4, true);
-
-        // Can't do bit arithmetic above 32-bits in JS so combine using power-of-two math
-        const v = a + (b * Math.pow(2, 32));
+        // Read as a double to match Buffer_WriteU64
+        const v = view.getFloat64(offset, true);
 
         // TODO(don): Potentially massive data loss!
-        snapshots_view.setFloat32(offset, v);
+        view.setFloat32(offset, v, true);
     }
 
 
     function SInt64ToFloat32(view, offset)
     {
-        // Unpack as two 32-bit integers so we have a vague attempt at reconstructing the value
-        const a = view.getUint32(offset + 0, true);
-        const b = view.getUint32(offset + 4, true);
-
-        // Is this negative?
-        if (b & 0x80000000)
-        {
-            // Can only convert from twos-complement with 32-bit arithmetic so shave off the upper 32-bits
-            // TODO(don): Crazy data loss here
-            const v = -(~(a - 1));
-        }
-        else
-        {
-            // Can't do bit arithmetic above 32-bits in JS so combine using power-of-two math
-            const v = a + (b * Math.pow(2, 32));
-        }
+        // Read as a double to match Buffer_WriteU64
+        const v = view.getFloat64(offset, true);
 
         // TODO(don): Potentially massive data loss!
-        snapshots_view.setFloat32(offset, v);
+        view.setFloat32(offset, v, true);
     }
 
 
@@ -591,6 +573,7 @@ Remotery = (function()
                 case 5:
                     SInt64ToFloat32(snapshots_view, offset + 16);
                     SInt64ToFloat32(snapshots_view, offset + 24);
+                    break;
                 case 6:
                     UInt64ToFloat32(snapshots_view, offset + 16);
                     UInt64ToFloat32(snapshots_view, offset + 24);


### PR DESCRIPTION
_NOTE: This pull request includes a handful of fixes that aren't strictly related to Vulkan sampling which I'll list below. They could be pulled out into a separate change if required._
1. _Fix `Remotery_Destructor`: Move clearing of `g_Remotery` to after graphics API-specific deletion/unbind calls, avoiding crashes because of unchecked access to g_Remotery._
2. _Fix `RMT_ARCH_64BIT`: Check `__arm64__` as well._
3. _Fix `rmt_GetLastErrorMessage` declaration: Enclose inside `extern "C"` block for C++ users._
4. _Fix `rmt_ScopedD3D12Sample`: Remove extra parens in end-of-scope object declaration which confuse some compilers that think it's a function declaration (most vexing parse)._
5. _Fix `Remotery.js` deserialization of `Uint64` and `Sint64` properties: `Remotery.c` already converts these to `rmtF64` prior to sending them over the socket._
6. _Add support for thread names on MacOS via `pthread_setname_np` and `pthread_getname_np`._

This is a first-pass implementation of Vulkan sampling support for Remotery based on the D3D12 implementation. It currently expects a handful of things about the user's Vulkan environment that are likely more restrictive than necessary but make the implementation much simpler.

- The user must either use Vulkan 1.2 with the `hostQueryReset` and `timelineSemaphore` features enabled, or have enabled the extensions `VK_EXT_host_query_reset` and `VK_KHR_timeline_semaphore`. These features/extensions are pretty widely supported so it seems maybe reasonable to require that users enable them; without them the implementation gets reasonably more complex and less performant.
- The user must enable the extension `VK_EXT_calibrated_timestamps`. It'd probably be pretty easy to make usage of this extension optional.
- The implementation always loads Vulkan functions dynamically. This is generally the most-preferred method, but it might be nicer to instead just have the user provide all the functions as a configuration option up-front. Unfortunately that's difficult without a bunch of horrible forward declarations, or including Vulkan.h in Remotery.h.
- The way I'm passing `vkGetInstanceProcAddr` feels very hacky, definitely open to suggestions here.
- I've left a handful of `TODO(valakor)`'s in the code for potential future improvement points.
- I've tried to do everything to support Windows+MacOS+Linux but it's possible I missed some things on non-Windows platforms. Mac is especially tricky since the normal Vulkan API doesn't understand that Metal doesn't support writing timestamps inside render/compute passes, but this is true for any user of Vulkan via MoltenVK.

I'm open to discussion/feedback about this implementation!