### PR TITLE
Fixed linking of _rmt_(Bind|Unbind)Metal when including from Obj-C++

### DIFF
--- a/lib/Remotery.h
+++ b/lib/Remotery.h
@@ -1197,16 +1197,17 @@ RMT_API const char*         _rmt_PropertyGetName(rmtProperty* property);
 RMT_API const char*         _rmt_PropertyGetDescription(rmtProperty* property);
 RMT_API rmtPropertyValue    _rmt_PropertyGetValue(rmtProperty* property);
 
-#ifdef __cplusplus
-
-}
-#endif
 
 #if RMT_USE_METAL
 #ifdef __OBJC__
 RMT_API void _rmt_BindMetal(id command_buffer);
 RMT_API void _rmt_UnbindMetal();
 #endif
+#endif
+
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif  // RMT_ENABLED


### PR DESCRIPTION
When including the main `Remotery.h` header from an Objective-C++ source file (`.mm`), `_rmt_BindMetal` and `_rmt_UnbindMetal` aren't declared with the C-linkage but `RemoteryMetal.mm` defines them as such.