### PR TITLE
Fix for rmt_GetLastErrorMessage do not report message for startup fail

### DIFF
--- a/lib/Remotery.c
+++ b/lib/Remotery.c
@@ -3136,6 +3136,7 @@ static rmtError TCPSocket_RunServer(TCPSocket* tcp_socket, rmtU16 port, rmtBool 
     sin.sin_port = htons(port);
     if (bind(s, (struct sockaddr*)&sin, sizeof(sin)) == SOCKET_ERROR)
     {
+        closesocket(s);
         return rmtMakeError(RMT_ERROR_RESOURCE_ACCESS_FAIL, "Can't bind a socket for the server");
     }
 
@@ -6710,7 +6711,7 @@ static rmtError Remotery_SerialisePropertySnapshots(Buffer* bin_buf, Msg_Propert
             case RMT_PropertyType_rmtGroup:
                 rmtTry(Buffer_Write(bin_buf, empty_group, 16));
                 break;
-            
+
             // All value ranges here are double-representable, so convert them early in C where it's cheap
             case RMT_PropertyType_rmtBool:
                 rmtTry(Buffer_WriteF64(bin_buf, snapshot->value.Bool));
@@ -7196,15 +7197,18 @@ static void Remotery_Destructor(Remotery* rmt)
     rmtDelete(rmtMessageQueue, rmt->mq_to_rmt_thread);
 
     rmtDelete(Server, rmt->server);
-    
+
     // Free the error message TLS
-    // TODO(don): The allocated messages will need to be freed as well
+    // TODO(don): Clarify better way to allow user to get a error msg on init fail
     if (g_lastErrorMessageTlsHandle != TLS_INVALID_HANDLE)
     {
-        tlsFree(g_lastErrorMessageTlsHandle);
-        g_lastErrorMessageTlsHandle = TLS_INVALID_HANDLE;
+        if (tlsGet(g_lastErrorMessageTlsHandle) == NULL)
+        {
+            tlsFree(g_lastErrorMessageTlsHandle);
+            g_lastErrorMessageTlsHandle = TLS_INVALID_HANDLE;
+        }
     }
-    
+
     mtxDelete(&rmt->propertyMutex);
 }
 
@@ -8718,7 +8722,7 @@ static rmtError CreateQueryHeap(D3D12BindImpl* bind, ID3D12Device* d3d_device, I
         {
             return rmtMakeError(RMT_ERROR_INVALID_INPUT, "Copy queues on this device do not support timestamps");
         }
-        
+
         query_heap_type = D3D12_QUERY_HEAP_TYPE_COPY_QUEUE_TIMESTAMP;
     }*/
     #else
@@ -8912,7 +8916,7 @@ static rmtError D3D12MarkFrame(D3D12BindImpl* bind)
 
     // Chain to the next bind here so that root calling code doesn't need to know the definition of D3D12BindImpl
     rmtTry(D3D12MarkFrame(bind->next));
-    
+
     return RMT_ERROR_NONE;
 }
 
@@ -9059,7 +9063,7 @@ RMT_API void _rmt_BeginD3D12Sample(rmtD3D12Bind* bind, void* command_list, rmtPS
 
     if (g_Remotery == NULL || bind == NULL)
         return;
-    
+
     assert(command_list != NULL);
 
     if (ThreadProfilers_GetCurrentThreadProfiler(g_Remotery->threadProfilers, &thread_profiler) == RMT_ERROR_NONE)
@@ -11007,7 +11011,7 @@ RMT_API rmtError _rmt_PropertySnapshotAll()
 
     // Mark current allocation count so we can quickly calculate the number of snapshots being sent
     nb_snapshot_allocs = g_Remotery->propertyAllocator->nb_inuse;
-    
+
     // Snapshot from the root into a linear list
     first_snapshot = NULL;
     prev_snapshot = NULL;

--- a/lib/Remotery.h
+++ b/lib/Remotery.h
@@ -51,7 +51,7 @@ documented just below this comment.
 #define RMT_ENABLED 1
 #endif
 
-// Help performance of the server sending data to the client by marking this machine as little-endian 
+// Help performance of the server sending data to the client by marking this machine as little-endian
 #ifndef RMT_ASSUME_LITTLE_ENDIAN
 #define RMT_ASSUME_LITTLE_ENDIAN 0
 #endif
@@ -305,10 +305,10 @@ typedef enum rmtError
     RMT_ERROR_SOCKET_INVALID_POLL,              // Poll attempt on an invalid socket
     RMT_ERROR_SOCKET_SELECT_FAIL,               // Server failed to call select on socket
     RMT_ERROR_SOCKET_POLL_ERRORS,               // Poll notified that the socket has errors
-    RMT_ERROR_SOCKET_SEND_FAIL,                 // Unrecoverable error occured while client/server tried to send data
+    RMT_ERROR_SOCKET_SEND_FAIL,                 // Unrecoverable error occurred while client/server tried to send data
     RMT_ERROR_SOCKET_RECV_NO_DATA,              // No data available when attempting a receive
     RMT_ERROR_SOCKET_RECV_TIMEOUT,              // Timed out trying to receive data
-    RMT_ERROR_SOCKET_RECV_FAILED,               // Unrecoverable error occured while client/server tried to receive data
+    RMT_ERROR_SOCKET_RECV_FAILED,               // Unrecoverable error occurred while client/server tried to receive data
 
     // WebSocket errors
     RMT_ERROR_WEBSOCKET_HANDSHAKE_NOT_GET,      // WebSocket server handshake failed, not HTTP GET
@@ -392,7 +392,7 @@ typedef struct rmtSettings
     rmtBool limit_connections_to_localhost;
 
     // Whether to enable runtime thread sampling that discovers which processors a thread is running
-    // on. This will suspend and resume threads from outside repeatdly and inject code into each
+    // on. This will suspend and resume threads from outside repeatedly and inject code into each
     // thread that automatically instruments the processor.
     // Default: Enabled
     rmtBool enableThreadSampler;
@@ -423,7 +423,7 @@ typedef struct rmtSettings
     rmtSampleTreeHandlerPtr sampletree_handler;
     void* sampletree_context;
 
-    // Callback pointer for traversing the prpperty graph
+    // Callback pointer for traversing the property graph
     rmtPropertyHandlerPtr snapshot_callback;
     void* snapshot_context;
 
@@ -452,7 +452,7 @@ typedef struct rmtSettings
 #define rmt_CreateGlobalInstance(rmt)                                               \
     RMT_OPTIONAL_RET(RMT_ENABLED, _rmt_CreateGlobalInstance(rmt), RMT_ERROR_NONE)
 
-// Shutsdown Remotery, requiring its pointer to be passed to ensure you are destroying the correct instance.
+// Shutdown Remotery, requiring its pointer to be passed to ensure you are destroying the correct instance.
 #define rmt_DestroyGlobalInstance(rmt)                                              \
     RMT_OPTIONAL(RMT_ENABLED, _rmt_DestroyGlobalInstance(rmt))
 
@@ -716,7 +716,7 @@ typedef enum
 // A property value as a union of all its possible types
 typedef union rmtPropertyValue
 {
-    // C++ requires function-based construction of property values because it has no designated initialiser support until C++20
+    // C++ requires function-based construction of property values because it has no designated initializer support until C++20
     #ifdef __cplusplus
         // These are static Make calls, rather than overloaded constructors, because `rmtBool` is the same type as `rmtU32`
         static rmtPropertyValue MakeBool(rmtBool v) { rmtPropertyValue pv; pv.Bool = v; return pv; }
@@ -754,7 +754,7 @@ typedef struct rmtProperty
 
     // Last frame value to see if previous value needs to be updated
     rmtPropertyValue lastFrameValue;
-    
+
     // Previous value only if it's different from the current value, and when it changed
     rmtPropertyValue prevValue;
     rmtU32 prevValueFrame;
@@ -841,8 +841,8 @@ typedef struct rmtProperty
 #define _rmt_PropertyDefine(type, name, default_value, flags, desc, ...) \
     rmtProperty name = { RMT_FALSE, RMT_PropertyType_##type, flags, default_value, default_value, default_value, 0, #name, desc, default_value, __VA_ARGS__ };
 
-// C++ doesn't support designated initialisers until C++20
-// Worth checking for C++ designated initialisers to remove the function call in debug builds
+// C++ doesn't support designated initializer until C++20
+// Worth checking for C++ designated initializer to remove the function call in debug builds
 #ifdef __cplusplus
 #define _rmt_MakePropertyValue(field, value) rmtPropertyValue::Make##field(value)
 #else

--- a/sample/dump.c
+++ b/sample/dump.c
@@ -15,7 +15,7 @@ rmt_PropertyDefine_U32(FrameCounter, 0, NoFlags, "What is the current frame numb
 
 
 void aggregateFunction() {
-    rmt_BeginCPUSample(aggregate, RMTSF_Aggregate);    
+    rmt_BeginCPUSample(aggregate, RMTSF_Aggregate);
     rmt_EndCPUSample();
 }
 void recursiveFunction(int depth) {
@@ -143,7 +143,7 @@ void sigintHandler(int sig_num) {
 
 int main() {
     Remotery* rmt;
-	rmtError error;
+    rmtError error;
 
     signal(SIGINT, sigintHandler);
 
@@ -157,10 +157,10 @@ int main() {
         settings->snapshot_context = 0;
     }
 
-	error = rmt_CreateGlobalInstance(&rmt);
+    error = rmt_CreateGlobalInstance(&rmt);
 
     if( RMT_ERROR_NONE != error) {
-		printf("Error launching Remotery %d\n", error);
+        printf("Error launching Remotery %d: %s\n", error, rmt_GetLastErrorMessage());
         return -1;
     }
 

--- a/sample/sample.c
+++ b/sample/sample.c
@@ -5,7 +5,7 @@
 #include "../lib/Remotery.h"
 
 void aggregateFunction() {
-    rmt_BeginCPUSample(aggregate, RMTSF_Aggregate);    
+    rmt_BeginCPUSample(aggregate, RMTSF_Aggregate);
     rmt_EndCPUSample();
 }
 void recursiveFunction(int depth) {
@@ -42,13 +42,13 @@ void sigintHandler(int sig_num) {
 
 int main( ) {
     Remotery *rmt;
-	rmtError error;
+    rmtError error;
 
     signal(SIGINT, sigintHandler);
 
-	error = rmt_CreateGlobalInstance(&rmt);
+    error = rmt_CreateGlobalInstance(&rmt);
     if( RMT_ERROR_NONE != error) {
-		printf("Error launching Remotery %d\n", error);
+        printf("Error launching Remotery %d: %s\n", error, rmt_GetLastErrorMessage());
         return -1;
     }
 


### PR DESCRIPTION
Hello

This patch should resolve problem when initialization fails and error is not informative: `No error message`
Main problem: if init fails, 'destructor' will call automatically (by macro) and TLS, which store msg will be destroyed.

Maybe better solution to move TLS destruction to `_rmt_DestroyGlobalInstance` but I have concern which tread will call it. Maybe same, maybe different. In other words it still can be a leak in case of different treads for init/fint

Minor fix for closing socket if bind fails
Also fixed some style and grammar problems

You can verify this fix by running 2 instances of example